### PR TITLE
typo in variables.md

### DIFF
--- a/docs/types/ambient/variables.md
+++ b/docs/types/ambient/variables.md
@@ -5,7 +5,7 @@ For example to tell TypeScript about the [`process` variable](https://nodejs.org
 declare var process:any;
 ```
 
-> You don't *need* to do this for `process` as there is already a [community maintained `node.ts`](https://github.com/borisyankov/DefinitelyTyped/blob/master/node/node.d.ts)
+> You don't *need* to do this for `process` as there is already a [community maintained `node.d.ts`](https://github.com/borisyankov/DefinitelyTyped/blob/master/node/node.d.ts)
 
 This allows you to use the `process` variable without TypeScript complaining: 
 


### PR DESCRIPTION
there is a file (node.d.ts) referenced, but the text used to link it only displays node.ts.