### PR TITLE
Added TypeScript version warning for readonly feature

### DIFF
--- a/docs/types/readonly.md
+++ b/docs/types/readonly.md
@@ -1,4 +1,6 @@
 ## Readonly
+> ⚠️ This feature will be supported starting TypeScript 2.0 (see [Microsoft/TypeScript/pull/6532][1]).
+
 TypeScript's type system allows you to mark individual properties on an interface as `readonly`. This allows you to work in a functional way (unexpected mutation is bad):
 
 ```ts
@@ -155,4 +157,4 @@ function iTakeFoo(foo: Foo) {
 iTakeFoo(foo); // The foo argument is aliased by the foo parameter
 ```
 
-[](https://github.com/Microsoft/TypeScript/pull/6532)
+[1]: https://github.com/Microsoft/TypeScript/pull/6532


### PR DESCRIPTION
Currently, readonly feature is not yet available; it is planned for version 2.0.
Without any warning, it can be confusing for people accessing this page directly (I just faced it).