### PR TITLE
Fix minor typos

### DIFF
--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -53,7 +53,7 @@ logIfHasName(random); // okay
 logIfHasName({neme: 'I just misspelled name to neme'}); // Error: object literals must only specify known properties. `neme` is excessive here.
 ```
 
-The reason why only object literals are type checked this way is because having a object literal created on the spot and passed in with additional properties *that aren't actually used* is almost always a typo or a misunderstanding of the API.
+The reason why only object literals are type checked this way is because having an object literal created on the spot and passed in with additional properties *that aren't actually used* is almost always a typo or a misunderstanding of the API.
 
 ### Allowing extra properties
 
@@ -94,7 +94,7 @@ interface State {
 // You want to do: 
 this.setState({foo: "Hello"}); // Yay works fine!
 
-// Because of freshness its protected against typos as well!
+// Because of freshness it's protected against typos as well!
 this.setState({foos: "Hello"}}; // Error: Objects may only specify known properties
 
 // And still type checked


### PR DESCRIPTION
Unrelated concern: the sentence starting with "The reason why only object literals are type checked this way is because" seemed a little difficult to parse. I thought I'd bring that to your attention, in case you want to simplify.