### PR TITLE
'is called to' vs. 'is said to'

### DIFF
--- a/docs/classes-emit.md
+++ b/docs/classes-emit.md
@@ -64,7 +64,7 @@ After having tutored many people about this I find the following explanation to 
 1. effect of `new` on `this` inside the called function
 1. effect of `new` on `prototype` and `__proto__`
 
-All objects in JavaScript contain a `__proto__` member. This member is often not accessible in older browsers (sometimes documentation refers to this magical property as `[[prototype]]`). It has one objective: If a property is not found on an object during lookup (e.g. `obj.property`) then it is looked up at `obj.__proto__.property`. If it is still not found then `obj.__proto__.__proto__.property` till either: *it is found* or *the latest `.__proto__` itself is null*. This explains why JavaScript is called to support *prototypal inheritance* out of the box. This is shown in the following example, which you can run in the chrome console or nodejs:
+All objects in JavaScript contain a `__proto__` member. This member is often not accessible in older browsers (sometimes documentation refers to this magical property as `[[prototype]]`). It has one objective: If a property is not found on an object during lookup (e.g. `obj.property`) then it is looked up at `obj.__proto__.property`. If it is still not found then `obj.__proto__.__proto__.property` till either: *it is found* or *the latest `.__proto__` itself is null*. This explains why JavaScript is said to support *prototypal inheritance* out of the box. This is shown in the following example, which you can run in the chrome console or nodejs:
 
 ```ts
 var foo = {}


### PR DESCRIPTION
Sounds odd to my ear.
You might have also meant 
'This is called *prototypal inheritance* and is supported by JavaScript out of the box.