### PR TITLE
Config resolve extension should not be empty

### DIFF
--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -59,7 +59,7 @@ module.exports = {
     },
     resolve: {
         // Add `.ts` and `.tsx` as a resolvable extension.
-        extensions: ['', '.webpack.js', '.web.js', '.ts', '.tsx', '.js']
+        extensions: ['.webpack.js', '.web.js', '.ts', '.tsx', '.js']
     },
     module: {
         loaders: [


### PR DESCRIPTION
After executing webpack --watch throw the error:

Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema
.
 - configuration.resolve.extensions[0] should not be empty.

Also in the example repo, is configured with out empty string extension: https://github.com/basarat/react-typescript/blob/master/webpack.config.js