### PR TITLE
react and react-dom added as dev dependency

### DIFF
--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -91,7 +91,7 @@ Now if you make edits to your `ts` or `tsx` file webpack will generate `bundle.j
 If you are going to use React (which I highly recommend you give a look), here are a few more steps:
 
 ```
-npm install react react-dom --save-dev
+npm install react react-dom --save
 ```
 
 ```


### PR DESCRIPTION
With the command
npm install react react-dom --save-dev

react and react-dom dependencies are added as devDependencies instead of normal dependencies for execution.