### PR TITLE
Change bundle.js output path

### DIFF
--- a/docs/quick/browser.md
+++ b/docs/quick/browser.md
@@ -54,7 +54,7 @@ npm install typescript@next webpack ts-loader typings --save-dev
 module.exports = {
     entry: './src/app.tsx',
     output: {
-        path: './build',  
+        path: './dist',  
         filename: 'bundle.js'
     },
     resolve: {


### PR DESCRIPTION
The script tag on index.html file reference to "./dist" path, but in webpack.config.js the output path is configured with "./build" path