### PR TITLE
Update deprecated node.d.ts to index.d.ts

### DIFF
--- a/docs/types/ambient/variables.md
+++ b/docs/types/ambient/variables.md
@@ -5,7 +5,7 @@ For example to tell TypeScript about the [`process` variable](https://nodejs.org
 declare var process: any;
 ```
 
-> You don't *need* to do this for `process` as there is already a [community maintained `node.d.ts`](https://github.com/DefinitelyTyped/tsd/blob/master/typings/node/node.d.ts).
+> You don't *need* to do this for `process` as there is already a [community maintained `node.d.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/node/index.d.ts).
 
 This allows you to use the `process` variable without TypeScript complaining:
 


### PR DESCRIPTION
Currently pointing to old node.d.ts in a deprecated repo.
Should point to index.d.ts from the DefinitelyTypes repo.

See comments from blakeembrey @ https://github.com/basarat/typescript-book/pull/242