### PR TITLE
Correct a possible mistake.

### DIFF
--- a/docs/project/modules.md
+++ b/docs/project/modules.md
@@ -34,6 +34,6 @@ If you want to use stuff from `foo.ts` in `bar.ts` *you need to explicitly impor
 import {foo} from "./foo";
 var bar = foo; // allowed
 ```
-Using an `import` in `bar.ts` not only allows you to bring in stuff from other files, but also marks the file `foo.ts` as a *module* and therefore `foo.ts` doesn't pollute the global namespace either.
+Using an `import` in `bar.ts` not only allows you to bring in stuff from other files, but also marks the file `bar.ts` as a *module* and therefore declarations in `bar.ts` doesn't pollute the global namespace either.
 
 What JavaScript is generated from a given TypeScript file that uses external modules is driven by the compiler flag called `module`.


### PR DESCRIPTION
Inferring from your argument, I believe you were trying to express: using `export` in foo.ts makes foo.ts a module, using `import` in bar.ts makes bar.ts a module.