### PR TITLE
Crazy interface exmaple does not compile

### DIFF
--- a/docs/types/interfaces.md
+++ b/docs/types/interfaces.md
@@ -93,8 +93,6 @@ interface CrazyConstructable {
 You would essentially have something like:
 
 ```ts
-
-
 class CrazyClass implements Crazy {
     constructor(public hello: number) {
     }

--- a/docs/types/interfaces.md
+++ b/docs/types/interfaces.md
@@ -82,22 +82,28 @@ Consider the following interface where something is callable with `new`:
 
 ```ts
 interface Crazy {
-    new (): {
         hello: number
-    };
+}
+
+interface CrazyConstructable {
+    new (n: number): Crazy;
 }
 ```
 
 You would essentially have something like:
 
 ```ts
+
+
 class CrazyClass implements Crazy {
-    constructor() {
-        return { hello: 123 };
+    constructor(public hello: number) {
     }
 }
 // Because
-const crazy = new CrazyClass(); // crazy would be {hello:123}
+    var crazyCtor: CrazyConstructable = CrazyClass;
+    const crazyObj = new crazyCtor(123); // crazyObj would be {hello:123}
 ```
 
 You can *declare* all the crazy JS out there with interfaces and even use them safely from TypeScript. Doesn't mean you can use TypeScript classes to implement them.
+In the case above, you cannot implement CrazyConstructable type as it cannot be instantiated due to the `new` member.
+CrazyConstructable can only be used as a constructor type for the Crazy type instantiation. 


### PR DESCRIPTION
Hi Basarat,

Finally I managed to make the pull request. Thanks for the help.

I notice that on the interfaces.md file the interface crazy could not be implemented in a class (please check here: Microsoft/TypeScript#8917) and I made a fix with some text to explain better the pattern.
I also fixed the constructor to not return any value as it seems not to be possible. Please check here: Microsoft/TypeScript#11588