### PR TITLE
Changed 'okay' comment to error message

### DIFF
--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -50,7 +50,7 @@ var random = { note: `I don't have a name property` };
 
 logIfHasName(person); // okay
 logIfHasName(animal); // okay
-logIfHasName(random); // okay
+logIfHasName(random); // Error: Type '{ note: string; }' has no properties in common with type '{ name?: string; }'
 logIfHasName({neme: 'I just misspelled name to neme'}); // Error: object literals must only specify known properties. `neme` is excessive here.
 ```
 


### PR DESCRIPTION
I'm new to TypeScript but it struck me that this particular example doesn't compile (anymore?)
The 'random' variable isn't really that different than the 'neme' line.

![wrongerrormessage](https://user-images.githubusercontent.com/9861966/30418263-b21e2b22-9932-11e7-9619-572d986f36b3.jpg)
