### PR TITLE
Small operators fix

### DIFF
--- a/docs/iterators.md
+++ b/docs/iterators.md
@@ -158,7 +158,7 @@ class Fib implements IterableIterator<number> {
     var current = this.fn1;
     this.fn1 = this.fn2;
     this.fn2 = current + this.fn1;
-    if (this.maxValue && current <= this.maxValue) {
+    if (!this.maxValue || current <= this.maxValue) {
       return {
         done: false,
         value: current


### PR DESCRIPTION
I think
```
this.maxValue && current <= this.maxValue
```
would make this code fail
```
let fib = new Fib();

fib.next() //{ done: false, value: 0 }
fib.next() //{ done: false, value: 1 }
fib.next() //{ done: false, value: 1 }
fib.next() //{ done: false, value: 2 }
fib.next() //{ done: false, value: 3 }
fib.next() //{ done: false, value: 5 }
```
because maxValue would be undefined, and .next would return
```
{
    done: true,
    value: null
}
```