### PR TITLE
Fix const name to avoid misunderstanding

### DIFF
--- a/docs/types/callable.md
+++ b/docs/types/callable.md
@@ -33,7 +33,7 @@ const overloaded: Overloaded = (foo) => foo;
 
 // example usage
 const str = overloaded(''); // str is inferred string
-const number = overloaded(123); // num is inferred number
+const num = overloaded(123); // num is inferred number
 ```
 
 Of course like *all* bodies of interfaces / types you can use these as variable type annotations e.g. 


### PR DESCRIPTION
I think changing `number` to `num`, when comment says `num` is desired.