### PR TITLE
A new way of creating an already existing variable in the surrounding scope. #412

### DIFF
--- a/docs/let.md
+++ b/docs/let.md
@@ -57,7 +57,7 @@ if (true) {
     var foo = 123;
 }
 ```
-However if the variable name is already taken by the surrounding scope then a new variable name is generated as shown (notice `_foo`):
+However if the variable name is already taken by the surrounding scope then a new variable name is generated as shown (notice `foo_1`):
 
 ```ts
 var foo = '123';
@@ -69,12 +69,12 @@ if (true) {
 
 var foo = '123';
 if (true) {
-    var _foo = 123; // Renamed
+    var foo_1 = 123; // Renamed
 }
 ```
 
 #### Switch
-You can wrap your `case` bodies in `{}` to reuse variable names reliably in different `case` statement as shown below: 
+You can wrap your `case` bodies in `{}` to reuse variable names reliably in different `case` statement as shown below:
 
 ```ts
 switch (name) {


### PR DESCRIPTION
If the variable name is already taken by the surrounding scope then a new variable name is generated as shown foo_1 instead of _foo. https://github.com/basarat/typescript-book/issues/412