### PR TITLE
Update typescript -> TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I've been looking at the issues that turn up commonly when people start using Ty
 * Guyz excellent book on Typescript(@typescriptlang) by @basarat ([link](https://twitter.com/deeinlove/status/813245965507260417))
 * Leaning on the legendary @basarat's "TypeScript Deep Dive" book heavily at the moment ([link](https://twitter.com/sitapati/status/814379404956532737))
 * numTimesPointedPeopleToBasaratsTypeScriptBook++; ([link](https://twitter.com/brocco/status/814227741696462848))
-* A book not only for typescript, a good one for deeper javascript knowledge as well. [link](https://www.gitbook.com/book/basarat/typescript/discussions/59)
+* A book not only for typescript, a good one for deeper JavaScript knowledge as well. [link](https://www.gitbook.com/book/basarat/typescript/discussions/59)
 * In my new job, we're using @typescriptlang, which I am new to. This is insanely helpful huge thanks, @basarat! [link](https://twitter.com/netchkin/status/855339390566096896)
 * Thank you for writing TypeScript Deep Dive. I have learned so much. [link](https://twitter.com/buctwbzs/status/857198618704355328?refsrc=email&s=11)
 * Loving @basarat's @typescriptlang online book basarat.gitbooks.io/typescript/# loaded with great recipes! [link](https://twitter.com/ericliprandi/status/857608837309677568)

--- a/docs/compiler/overview.md
+++ b/docs/compiler/overview.md
@@ -1,5 +1,5 @@
 # Compiler
-The typescript compiler source is located under the [`src/compiler`](https://github.com/Microsoft/TypeScript/tree/master/src/compiler) folder.
+The TypeScript compiler source is located under the [`src/compiler`](https://github.com/Microsoft/TypeScript/tree/master/src/compiler) folder.
 
 It is split into the follow key parts:
 * Scanner (`scanner.ts`)

--- a/docs/compiler/scanner.md
+++ b/docs/compiler/scanner.md
@@ -81,4 +81,4 @@ SemicolonToken 13 14
 ```
 
 ### Standalone scanner
-Even though the typescript parser has a singleton scanner you can create a standalone scanner using `createScanner` and use its `setText`/`setTextPos` to scan at different points in a file for your amusement.
+Even though the TypeScript parser has a singleton scanner you can create a standalone scanner using `createScanner` and use its `setText`/`setTextPos` to scan at different points in a file for your amusement.

--- a/docs/project/dynamic-import-expressions.md
+++ b/docs/project/dynamic-import-expressions.md
@@ -11,7 +11,7 @@ The thing is that webpack code splitting supports two similar techniques to achi
 
 Let’s see an example to figure out how to configure webpack + TypeScript 2.4.
 
-In the following code I want to **lazy load the library _moment_** but I am interested in code splitting as well, which means, having the moment library in a separate chunk of JS (javascript file) that will be loaded only when required.
+In the following code I want to **lazy load the library _moment_** but I am interested in code splitting as well, which means, having the moment library in a separate chunk of JS (JavaScript file) that will be loaded only when required.
 
 ```ts
 import(/* webpackChunkName: "momentjs" */ "moment")

--- a/docs/project/tsconfig.md
+++ b/docs/project/tsconfig.md
@@ -16,7 +16,7 @@ You can customize the compiler options using `compilerOptions`:
     "target": "es5",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs",                  /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
     "lib": [],                             /* Specify library files to be included in the compilation:  */
-    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "allowJs": true,                       /* Allow JavaScript files to be compiled. */
     "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */

--- a/docs/quick/nodejs.md
+++ b/docs/quick/nodejs.md
@@ -27,12 +27,12 @@ Now just add a `script` target to your `package.json` based on your application 
 So you can now run `npm start` and as you edit `index.ts`:
 
 * nodemon reruns its command (ts-node)
-* ts-node transpiles automatically picking up tsconfig.json and the installed typescript version,
-* ts-node runs the output javascript through Node.js.
+* ts-node transpiles automatically picking up tsconfig.json and the installed TypeScript version,
+* ts-node runs the output JavaScript through Node.js.
 
 ## Creating TypeScript node modules
 
-* [A lesson on creating typescript node modules](https://egghead.io/lessons/typescript-create-high-quality-npm-packages-using-typescript)
+* [A lesson on creating TypeScript node modules](https://egghead.io/lessons/typescript-create-high-quality-npm-packages-using-typescript)
 
 Using modules written in TypeScript is super fun as you get great compile time safety and autocomplete (essentially executable documentation).
 

--- a/docs/types/never.md
+++ b/docs/types/never.md
@@ -41,7 +41,7 @@ function foo(x: string | number): boolean {
   // Without a never type we would error :
   // - Not all code paths return a value (strict null checks)
   // - Or Unreachable code detected
-  // But because typescript understands that `fail` function returns `never`
+  // But because TypeScript understands that `fail` function returns `never`
   // It can allow you to call it as you might be using it for runtime safety / exhaustive checks.
   return fail("Unexhaustive!");
 }

--- a/docs/types/type-assertion.md
+++ b/docs/types/type-assertion.md
@@ -106,5 +106,5 @@ function handler(event: Event) {
 }
 ```
 
-#### How typescript determines if a single assertion is not enough
+#### How TypeScript determines if a single assertion is not enough
 Basically, the assertion from type `S` to `T` succeeds if either `S` is a subtype of `T` or `T` is a subtype of `S`. This is to provide extra safety when doing type assertions ... completely wild assertions can be very unsafe and you need to use `any` to be that unsafe.

--- a/docs/types/type-system.md
+++ b/docs/types/type-system.md
@@ -1,6 +1,6 @@
 # TypeScript Type System
 We covered the main features of the TypeScript Type System back when we discussed [Why TypeScript?](../why-typescript.md). The following are a few key takeaways from that discussion which don't need further explanation:
-* The type system in typescript is designed to be *optional* so that *your javascript is typescript*.
+* The type system in TypeScript is designed to be *optional* so that *your JavaScript is TypeScript*.
 * TypeScript does not block *JavaScript emit* in the presence of Type Errors, allowing you to *progressively update your JS to TS*.
 
 Now let's start with the *syntax* of the TypeScript type system. This way you can start using these annotations in your code immediately and see the benefit. This will prepare you for a deeper dive later.

--- a/docs/why-typescript.md
+++ b/docs/why-typescript.md
@@ -114,7 +114,7 @@ $(123).show(); // Error: selector needs to be a string
 We will discuss the details of creating TypeScript definitions for existing JavaScript in detail later once you know more about TypeScript (e.g. stuff like `interface` and the `any`).
 
 ## Future JavaScript => Now
-TypeScript provides a number of features that are planned in ES6 for current JavaScript engines (that only support ES5 etc). The typescript team is actively adding these features and this list is only going to get bigger over time and we will cover this in its own section. But just as a specimen here is an example of a class:
+TypeScript provides a number of features that are planned in ES6 for current JavaScript engines (that only support ES5 etc). The TypeScript team is actively adding these features and this list is only going to get bigger over time and we will cover this in its own section. But just as a specimen here is an example of a class:
 
 ```ts
 class Point {


### PR DESCRIPTION
Where appropriate:

Change 'typescript' to correct proper noun form 'TypeScript'
Change 'javascript' to correct proper noun form 'JavaScript'