### PR TITLE
Add comma after 'however'

### DIFF
--- a/docs/arrow-functions.md
+++ b/docs/arrow-functions.md
@@ -121,7 +121,7 @@ const child = new Child(123);
 console.log(child.callAdd(123)); // 246
 ```
 
-However they do not work with the `super` keyword when you try to override the function in a child class. Properties go on `this`. Since there is only one `this` such functions cannot participate in a call to `super` (`super` only works on prototype members). You can easily get around it by creating a copy of the method before overriding it in the child.
+However, they do not work with the `super` keyword when you try to override the function in a child class. Properties go on `this`. Since there is only one `this` such functions cannot participate in a call to `super` (`super` only works on prototype members). You can easily get around it by creating a copy of the method before overriding it in the child.
 
 ```ts
 class Adder {

--- a/docs/compiler/ast-tip-children.md
+++ b/docs/compiler/ast-tip-children.md
@@ -23,7 +23,7 @@ export function forEachChild<T>(node: Node, cbNode: (node: Node) => T, cbNodeArr
             // .... lots more
 ```
 
-Basically it checks `node.kind` and based on that assumes an interface offered by the `node` and calls the `cbNode` on the children. Note, however that this function doesn't call `visitNode` for *all* children (e.g. SyntaxKind.SemicolonToken). If you want *all* the children of a node in the AST just call `.getChildren` member function of the `Node`.
+Basically, it checks `node.kind` and based on that assumes an interface offered by the `node` and calls the `cbNode` on the children. However, note that this function doesn't call `visitNode` for *all* children (e.g. SyntaxKind.SemicolonToken). If you want *all* the children of a node in the AST just call `.getChildren` member function of the `Node`.
 
 E.g. here is a function that prints the verbose `AST` of a node:
 

--- a/docs/compiler/ast-tip-syntaxkind.md
+++ b/docs/compiler/ast-tip-syntaxkind.md
@@ -10,7 +10,7 @@ export const enum SyntaxKind {
     // ... LOTS more
 ```
 
-It's a `const enum` (a concept [we covered previously](../enums.md)) so that it gets *inlined* (e.g. `ts.SyntaxKind.EndOfFileToken` becomes `1`) and we don't get a dereferencing cost when working with the AST. However the compiler is compiled with `--preserveConstEnums` compiler flag so that the enum *is still available at runtime*. So in JavaScript you can use `ts.SyntaxKind.EndOfFileToken` if you want. Additionally you can convert these enum members to display strings using the following function:
+It's a `const enum` (a concept [we covered previously](../enums.md)) so that it gets *inlined* (e.g. `ts.SyntaxKind.EndOfFileToken` becomes `1`) and we don't get a dereferencing cost when working with the AST. However, the compiler is compiled with `--preserveConstEnums` compiler flag so that the enum *is still available at runtime*. So in JavaScript you can use `ts.SyntaxKind.EndOfFileToken` if you want. Additionally you can convert these enum members to display strings using the following function:
 
 ```ts
 export function syntaxKindToName(kind: ts.SyntaxKind) {

--- a/docs/compiler/ast-trivia.md
+++ b/docs/compiler/ast-trivia.md
@@ -1,5 +1,5 @@
 ### Trivia
-Trivia (called that because it's `trivial`) represent the parts of the source text that are largely insignificant for normal understanding of the code. For example; whitespace, comments, and even conflict markers. Trivia is *not stored* in the AST (to keep it lightweight). However it can be fetched *on demand* using a few `ts.*` APIs. 
+Trivia (called that because it's `trivial`) represent the parts of the source text that are largely insignificant for normal understanding of the code. For example; whitespace, comments, and even conflict markers. Trivia is *not stored* in the AST (to keep it lightweight). However, it can be fetched *on demand* using a few `ts.*` APIs. 
 
 Before we show them you need to understand the following:
 

--- a/docs/const.md
+++ b/docs/const.md
@@ -54,7 +54,7 @@ const foo = { bar: 123 };
 foo = { bar: 456 }; // ERROR : Left hand side of an assignment expression cannot be a constant
 ```
 
-However it still allows sub properties of objects to be mutated, as shown below:
+However, it still allows sub properties of objects to be mutated, as shown below:
 
 ```ts
 const foo = { bar: 123 };

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -9,7 +9,7 @@
 * [Enum with static functions](#enum-with-static-functions)
 
 ### Enums
-An enum is a way to organize a collection of related values. Many other programming languages (C/C#/Java) have an `enum` data type but JavaScript does not. However TypeScript does. Here is an example definition of a TypeScript enum:
+An enum is a way to organize a collection of related values. Many other programming languages (C/C#/Java) have an `enum` data type but JavaScript does not. However, TypeScript does. Here is an example definition of a TypeScript enum:
 
 ```ts
 enum CardSuit {
@@ -86,7 +86,7 @@ enum Color {
 }
 ```
 
-However you can change the number associated with any enum member by assigning to it specifically. This is demonstrated below where we start at 3 and start incrementing from there:
+However, you can change the number associated with any enum member by assigning to it specifically. This is demonstrated below where we start at 3 and start incrementing from there:
 
 ```ts
 enum Color {
@@ -229,7 +229,7 @@ i.e. the compiler:
 1. Does not generate any JavaScript for the enum definition (there is no `Tristate` variable at runtime) as its usages are inlined.
 
 ##### Const enum preserveConstEnums
-Inlining has obvious performance benefits. The fact that there is no `Tristate` variable at runtime is simply the compiler helping you out by not generating JavaScript that is not actually used at runtime. However you might want the compiler to still generate the JavaScript version of the enum definition for stuff like *number to string* or *string to number* lookups as we saw. In this case you can use the compiler flag `--preserveConstEnums` and it will still generate the `var Tristate` definition so that you can use `Tristate["False"]` or `Tristate[0]` manually at runtime if you want. This does not impact *inlining* in any way.
+Inlining has obvious performance benefits. The fact that there is no `Tristate` variable at runtime is simply the compiler helping you out by not generating JavaScript that is not actually used at runtime. However, you might want the compiler to still generate the JavaScript version of the enum definition for stuff like *number to string* or *string to number* lookups as we saw. In this case you can use the compiler flag `--preserveConstEnums` and it will still generate the `var Tristate` definition so that you can use `Tristate["False"]` or `Tristate[0]` manually at runtime if you want. This does not impact *inlining* in any way.
 
 ### Enum with static functions
 You can use the declaration `enum` + `namespace` merging to add static methods to an enum. The following demonstrates an example where we add a static member `isBusinessDay` to an enum `Weekday`:

--- a/docs/errors/interpreting-errors.md
+++ b/docs/errors/interpreting-errors.md
@@ -36,7 +36,7 @@ The objective of the succint error message is to provide an example *conventiona
 ```
 TS2345: Argument of type '{ foo: number; bar: () => string; }' is not assignable to parameter of type 'SomethingComplex'.
 ```
-It is fairly self explanatory. However it doesn't provide a deeper breakdown of *why* the error is happening. That is what the *detiled* error message is for.
+It is fairly self explanatory. However, it doesn't provide a deeper breakdown of *why* the error is happening. That is what the *detiled* error message is for.
 
 ### Detailed
 For this example the detailed version looks like: 

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -1,6 +1,6 @@
 ## Generators
 
-> NOTE: You cannot use generators in TypeScript in a meaningful way (the ES5 emitter is in progress). However that will change soon so we still have this chapter.
+> NOTE: You cannot use generators in TypeScript in a meaningful way (the ES5 emitter is in progress). However, that will change soon so we still have this chapter.
 
 `function *` is the syntax used to create a *generator function*. Calling a generator function returns a *generator object*. The generator object just follows the [iterator][iterator] interface (i.e. the `next`, `return` and `throw` functions). 
 

--- a/docs/iterators.md
+++ b/docs/iterators.md
@@ -65,7 +65,7 @@ let component = iteratorResult1.value; //Component { name: 'top' }
 ```
 Again. Iterator itself is not a TypeScript feature, this code could work without
 implementing Iterator and IteratorResult interfaces explicitly.
-However it is very helpful to use these common
+However, it is very helpful to use these common
 ES6 [interfaces](./types/interfaces.md) for code consistency.
 
 Ok, Nice, but could be more helpful. ES6 defines the *iterable protocol*
@@ -188,7 +188,7 @@ for(let num of fibMax21) {
 ```
 
 #### Building code with iterators for ES5 target
-Code examples above require ES6 target, however it could work
+Code examples above require ES6 target. However, it could work
 with ES5 target as well if target JS engine supports `Symbol.iterator`.
 This can be achieved by using ES6 lib with ES5 target
 (add es6.d.ts to your project) to make it compile.

--- a/docs/javascript/equality.md
+++ b/docs/javascript/equality.md
@@ -9,8 +9,8 @@ console.log(5 == "5"); // true   , TS Error
 console.log(5 === "5"); // false , TS Error
 ```
 
-However the choices JavaScript makes are not always ideal. For example in the below example the first statement is false
-because `""` and `"0"` are both strings and are clearly not equal. However in the second case both `0` and the
+However, the choices JavaScript makes are not always ideal. For example, in the below example the first statement is false
+because `""` and `"0"` are both strings and are clearly not equal. However, in the second case both `0` and the
 empty string (`""`) are falsy (i.e. behave like `false`) and are therefore equal with respect to `==`. Both statements
 are false when you use `===`.
 
@@ -43,7 +43,7 @@ import * as deepEqual from "deep-equal";
 console.log(deepEqual({a:123},{a:123})); // True
 ```
 
-However quite commonly you don't need deep checks and all you really need is to check by some `id` e.g. 
+However, quite commonly you don't need deep checks and all you really need is to check by some `id` e.g. 
 
 ```ts
 type IdDisplay = {

--- a/docs/javascript/null-undefined.md
+++ b/docs/javascript/null-undefined.md
@@ -106,4 +106,4 @@ function toInt(str: string): { valid: boolean, int?: number } {
 ### Final thoughts
 TypeScript team doesn't use `null` : [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined) and it hasn't caused any problems. Douglas Crockford thinks [`null` is a bad idea](https://www.youtube.com/watch?v=PSGEjv3Tqo0&feature=youtu.be&t=9m21s) and we should all just use `undefined`.
 
-However NodeJS style code bases uses `null` for Error arguments as standard as it denotes `Something is currently unavailable`. I personally don't care to distinguish between the two as most projects use libraries with differing opinions and just rule out both with `== null`.
+However, NodeJS style code bases uses `null` for Error arguments as standard as it denotes `Something is currently unavailable`. I personally don't care to distinguish between the two as most projects use libraries with differing opinions and just rule out both with `== null`.

--- a/docs/javascript/recap.md
+++ b/docs/javascript/recap.md
@@ -4,7 +4,7 @@ There were (and will continue to be) a lot of competitors in *Some syntax* to *J
 
 ![JavaScript is TypeScript](https://raw.githubusercontent.com/basarat/typescript-book/master/images/venn.png)
 
-However it does mean that *you need to learn JavaScript* (the good news is *you **only** need to learn JavaScript*). TypeScript is just standardizing all the ways you provide *good documentation* on JavaScript.
+However, it does mean that *you need to learn JavaScript* (the good news is *you **only** need to learn JavaScript*). TypeScript is just standardizing all the ways you provide *good documentation* on JavaScript.
 
 * Just giving you a new syntax doesn't help fix bugs (looking at you CoffeeScript).
 * Creating a new language abstracts you too far from your runtimes, communities (looking at you Dart).

--- a/docs/jsx/react.md
+++ b/docs/jsx/react.md
@@ -138,7 +138,7 @@ Something like the following works fine:
 function foo<T>(x: T): T { return x; }
 ```
 
-However using an arrow generic function will not:
+However, using an arrow generic function will not:
 
 ```ts
 const foo = <T>(x: T) => x; // ERROR : unclosed `T` tag

--- a/docs/let.md
+++ b/docs/let.md
@@ -57,7 +57,7 @@ if (true) {
     var foo = 123;
 }
 ```
-However if the variable name is already taken by the surrounding scope then a new variable name is generated as shown (notice `foo_1`):
+However, if the variable name is already taken by the surrounding scope then a new variable name is generated as shown (notice `foo_1`):
 
 ```ts
 var foo = '123';

--- a/docs/options/strictNullChecks.md
+++ b/docs/options/strictNullChecks.md
@@ -8,7 +8,7 @@ foo = null; // Okay
 foo = undefined; // Okay
 ```
 
-This is modelled after how a lot of people write JavaScript. However like all things, TypeScript allows you to be *explicit* about what *can and cannot be* assigned a `null` or `undefined`.
+This is modelled after how a lot of people write JavaScript. However, like all things, TypeScript allows you to be *explicit* about what *can and cannot be* assigned a `null` or `undefined`.
 
 In strict null checking mode, `null` and `undefined` are different:
 

--- a/docs/project/external-modules.md
+++ b/docs/project/external-modules.md
@@ -252,7 +252,7 @@ Type inference needs to be done *upfront*. This means that if you want to use so
 import foo = require('foo');
 var bar: foo.SomeType;
 ```
-However you might want to only load the file `foo` at runtime under certain conditions. For such cases you should use the `import`ed name only in *type annotations* and **not** as a *variable*. This removes any *upfront* runtime dependency code being injected by TypeScript. Then *manually import* the actual module using code that is specific to your module loader.
+However, you might want to only load the file `foo` at runtime under certain conditions. For such cases you should use the `import`ed name only in *type annotations* and **not** as a *variable*. This removes any *upfront* runtime dependency code being injected by TypeScript. Then *manually import* the actual module using code that is specific to your module loader.
 
 As an example, consider the following `commonjs` based code where we only load a module `'foo'` on a certain function call:
 
@@ -288,7 +288,7 @@ Similar to the lazy loading use case certain module loaders (commonjs/node and a
 
 ### Use case: Ensure Import
 
-Sometimes you want to load a file just for the side effect (e.g. the module might register itself with some library like [CodeMirror addons](https://codemirror.net/doc/manual.html#addons) etc.). However if you just do a `import/require` the transpiled JavaScript will not contain a dependency on the module and your module loader (e.g. webpack) might completely ignore the import. In such cases you can use a `ensureImport` variable to ensure that the compiled JavaScript takes a dependency on the module e.g.:
+Sometimes you want to load a file just for the side effect (e.g. the module might register itself with some library like [CodeMirror addons](https://codemirror.net/doc/manual.html#addons) etc.). However, if you just do a `import/require` the transpiled JavaScript will not contain a dependency on the module and your module loader (e.g. webpack) might completely ignore the import. In such cases you can use a `ensureImport` variable to ensure that the compiled JavaScript takes a dependency on the module e.g.:
 
 ```ts
 import foo = require('./foo');

--- a/docs/project/tsconfig.md
+++ b/docs/project/tsconfig.md
@@ -68,7 +68,7 @@ You can customize the compiler options using `compilerOptions`:
 These (and more) compiler options will be discussed later.
 
 ### TypeScript compiler
-Good IDEs come with built in support for on the fly `ts` to `js` compilation. If however you want to run the TypeScript compiler manually from the command line when using `tsconfig.json` you can do it in a few ways.
+Good IDEs come with built in support for on the fly `ts` to `js` compilation. However, if you want to run the TypeScript compiler manually from the command line when using `tsconfig.json`, you can do it in a few ways:
 * Just run `tsc` and it will look for `tsconfig.json` in the current as well as all parent folders till it finds it.
 * Run `tsc -p ./path-to-project-directory`. Of course the path can be absolute or relative to the current directory.
 

--- a/docs/promise.md
+++ b/docs/promise.md
@@ -52,7 +52,7 @@ Simple enough, it takes a callback, passes any file system errors to the callbac
 1. Never call the callback twice.
 1. Never throw an error.
 
-This simple function however fails to accommodate for point two. In fact `JSON.parse` throws an error if it is passed bad JSON and the callback never gets called and the application crashes. This is demonstrated in the below example:
+However, this simple function fails to accommodate for point two. In fact, `JSON.parse` throws an error if it is passed bad JSON and the callback never gets called and the application crashes. This is demonstrated in the below example:
 
 ```ts
 import fs = require('fs');
@@ -102,7 +102,7 @@ loadJSON('invalid.json', function (err, data) {
 });
 ```
 
-However there is a subtle bug in this code. If the callback (`cb`), and not `JSON.parse`, throws an error, since we wrapped it in a `try`/`catch`, the `catch` executes and we call the callback again i.e. the callback gets called twice! This is demonstrated in the example below:
+However, there is a subtle bug in this code. If the callback (`cb`), and not `JSON.parse`, throws an error, since we wrapped it in a `try`/`catch`, the `catch` executes and we call the callback again i.e. the callback gets called twice! This is demonstrated in the example below:
 
 ```ts
 import fs = require('fs');
@@ -438,7 +438,7 @@ The reason why this function was simpler is because the "`loadFile`(async) + `JS
 ### Parallel control flow
 We have seen how trivial doing a serial sequence of async tasks is with promises. It is simply a matter of chaining `then` calls.
 
-However you might potentially want to run a series of async tasks and then do something with the results of all of these tasks. `Promise` provides a static `Promise.all` function that you can use to wait for `n` number of promises to complete. You provide it with an array of `n` promises and it gives you an array of `n` resolved values. Below we show Chaining as well as Parallel:
+However, you might potentially want to run a series of async tasks and then do something with the results of all of these tasks. `Promise` provides a static `Promise.all` function that you can use to wait for `n` number of promises to complete. You provide it with an array of `n` promises and it gives you an array of `n` resolved values. Below we show Chaining as well as Parallel:
 
 ```ts
 // an async function to simulate loading an item from some server

--- a/docs/testing/cypress.md
+++ b/docs/testing/cypress.md
@@ -249,7 +249,7 @@ cy.wait(waitMilliseconds);
 cy.get('#logoutNotification').should('be.visible');
 ```
 
-However it is recommended to mock time using `cy.clock` and forwarding time using `cy.tick` e.g. 
+However, it is recommended to mock time using `cy.clock` and forwarding time using `cy.tick` e.g. 
 
 ```ts
 cy.clock();

--- a/docs/tips/classesAreUseful.md
+++ b/docs/tips/classesAreUseful.md
@@ -23,7 +23,7 @@ function foo() {
 
 This is known as the *revealing module pattern* and quite common in JavaScript (taking advantage of JavaScript closure).
 
-If you use [*file modules* (which you really should as global scope is bad)](../project/modules.md) then *your file is effectively the same*. However there are too many cases where people will write code like the following:
+If you use [*file modules* (which you really should as global scope is bad)](../project/modules.md) then *your file is effectively the same*. However, there are too many cases where people will write code like the following:
 
 ```ts
 let someProperty;

--- a/docs/tips/singleton.md
+++ b/docs/tips/singleton.md
@@ -23,7 +23,7 @@ let something = new Singleton() // Error: constructor of 'Singleton' is private.
 let instance = Singleton.getInstance() // do something with the instance...
 ```
 
-However if you don't want lazy initialization you can instead just use a `namespace`: 
+However, if you don't want lazy initialization you can instead just use a `namespace`: 
 
 ```ts
 namespace Singleton {

--- a/docs/tips/staticConstructor.md
+++ b/docs/tips/staticConstructor.md
@@ -1,6 +1,6 @@
 # Static Constructors in TypeScript
 
-TypeScript `class` (like JavaScript `class`) cannot have a static constructor. However you can get the same effect quite easily by just calling it yourself: 
+TypeScript `class` (like JavaScript `class`) cannot have a static constructor. However, you can get the same effect quite easily by just calling it yourself: 
 
 ```ts
 class MyClass {

--- a/docs/types/@types.md
+++ b/docs/types/@types.md
@@ -19,7 +19,7 @@ npm install @types/jquery --save-dev
 
 By default any definitions that support global consumption are included automatically. E.g. for `jquery` you should be able to just start using `$` *globally* in your project.
 
-However for *libraries*  (like `jquery`) I generally recommend using *modules*:
+However, for *libraries*  (like `jquery`) I generally recommend using *modules*:
 
 ### Module `@types`
 

--- a/docs/types/advanced.md
+++ b/docs/types/advanced.md
@@ -10,7 +10,7 @@ The `?` annotation can be used before a function argument or member of an interf
 ## Specialized Parameters
 
 ## Function Overloads
-The JavaScript runtime does not have runtime support for function overloading. There can be only a single function body for any given name in scope. However people do support function overloading by utilizing the highly dynamic nature of JavaScript e.g. a getter and a setter:
+The JavaScript runtime does not have runtime support for function overloading. There can be only a single function body for any given name in scope. However, people do support function overloading by utilizing the highly dynamic nature of JavaScript e.g. a getter and a setter:
 
 ```ts
 var _value;
@@ -44,7 +44,7 @@ getOrSet(1); // set : 1
 console.log(getOrSet()); // get : 1
 ```
 
-Note that when you define function overloads this way, *the last signature is actually not callable*. You have to provide it however to help the implementer of the function be aware of the consequences of his overload signatures. For example in the following example the function with the signature `function callMe(v1?: any, v2?: any): any` is not open to public use:
+Note that when you define function overloads this way, *the last signature is actually not callable*. You have to provide it however, to help the implementer of the function be aware of the consequences of his overload signatures. For example, in the following example the function with the signature `function callMe(v1?: any, v2?: any): any` is not open to public use:
 
 ```ts
 function callMe(): number;

--- a/docs/types/discriminated-unions.md
+++ b/docs/types/discriminated-unions.md
@@ -191,7 +191,7 @@ let store = createStore(counter)
 
 // You can use subscribe() to update the UI in response to state changes.
 // Normally you'd use a view binding library (e.g. React Redux) rather than subscribe() directly.
-// However it can also be handy to persist the current state in the localStorage.
+// However, it can also be handy to persist the current state in the localStorage.
 
 store.subscribe(() =>
   console.log(store.getState())

--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -23,7 +23,7 @@ logName(animal); // okay
 logName(random); // Error: property `name` is missing
 ```
 
-However *structural* typing has a weakness in that it allows you to misleadingly think that something accepts more data than it actually does. This is demonstrated in the following code which TypeScript will error on as shown:
+However, *structural* typing has a weakness in that it allows you to misleadingly think that something accepts more data than it actually does. This is demonstrated in the following code which TypeScript will error on as shown:
 
 ```ts
 function logName(something: { name: string }) {

--- a/docs/types/functions.md
+++ b/docs/types/functions.md
@@ -48,7 +48,7 @@ function foo(sample: Foo) {
 }
 ```
 
-However it is generally a good idea to add these annotation to help with errors e.g.:
+However, it is generally a good idea to add these annotation to help with errors e.g.:
 
 ```ts
 function foo() {

--- a/docs/types/index-signatures.md
+++ b/docs/types/index-signatures.md
@@ -195,7 +195,7 @@ type FromSomeIndex<K extends string> = { [key in K]: number }
 
 This is not a common use case, but TypeScript compiler supports it nonetheless.
 
-However it has the restriction that the `string` indexer is more strict than the `number` indexer. This is intentional e.g. to allow typing stuff like:
+However, it has the restriction that the `string` indexer is more strict than the `number` indexer. This is intentional e.g. to allow typing stuff like:
 
 ```ts
 interface ArrStr {
@@ -264,7 +264,7 @@ const failsSilently: NestedCSS = {
 
 Sometimes you need to combine properties into the index signature. This is not advised, and you *should* use the Nested index signature pattern mentioned above. 
 
-However if you are modeling *existing JavaScript* you can get around it with an intersection type. The following shows an example of the error you will encounter without using an intersection:
+However, if you are modeling *existing JavaScript* you can get around it with an intersection type. The following shows an example of the error you will encounter without using an intersection:
 
 ```ts
 type FieldState = {

--- a/docs/types/interfaces.md
+++ b/docs/types/interfaces.md
@@ -15,7 +15,7 @@ interface Point {
 declare var myPoint: Point;
 ```
 
-However the beauty of *Sample B* is that if someone authors a library that builds on the `myPoint` library to add new members, they can easily add to the existing declaration of `myPoint`:
+However, the beauty of *Sample B* is that if someone authors a library that builds on the `myPoint` library to add new members, they can easily add to the existing declaration of `myPoint`:
 
 ```ts
 // Lib a.d.ts

--- a/docs/types/lib.d.ts.md
+++ b/docs/types/lib.d.ts.md
@@ -187,7 +187,7 @@ Similar variables and interfaces exist for other things that have both static an
 
 ### Example `string` redux
 
-We recommended creating a `global.d.ts` for maintainability reasons. However you can break into the *global namespace* from within *a file module* if you desire so. This is done using `declare global { /*global namespace here*/ }`. E.g. the previous example can also be done as:
+We recommended creating a `global.d.ts` for maintainability reasons. However, you can break into the *global namespace* from within *a file module* if you desire so. This is done using `declare global { /*global namespace here*/ }`. E.g. the previous example can also be done as:
 
 ```ts
 // Ensure this is treated as a module.
@@ -222,7 +222,7 @@ Once you have excluded the default `lib.d.ts` you can include a similarly named 
 
 Setting the compiler target to `es6` causes the `lib.d.ts` to include *additional* ambient declarations for more modern (es6) stuff like `Promise`. This magical effect of the compiler target changing the *ambience* of the code is desirable for some people and for others it's problematic as it conflates *code generation* with *code ambience*.
 
-However if you want finer grained control of your environment, you should use the `--lib` option which we discuss next.
+However, if you want finer grained control of your environment, you should use the `--lib` option which we discuss next.
 
 ### lib option
 

--- a/docs/types/never.md
+++ b/docs/types/never.md
@@ -15,7 +15,7 @@ Of course you can use this annotation yourself as well
 let foo: never; // Okay
 ```
 
-However `never` *can only ever be assigned to another never*. e.g.
+However, `never` *can only ever be assigned to another never*. e.g.
 
 ```ts
 let foo: never = 123; // Error: Type number is not assignable to never
@@ -53,9 +53,9 @@ And because `never` is only assignable to another `never` you can use it for *co
 
 # Confusion with `void`
 
-As soon as someone tells you that `never` is returned when a function never exits gracefully you intuitively want to think of it as the same as `void` However `void` is a Unit. `never` is a falsum.
+As soon as someone tells you that `never` is returned when a function never exits gracefully you intuitively want to think of it as the same as `void` However, `void` is a Unit. `never` is a falsum.
 
-A function that *returns* nothing returns a Unit `void`. However a function *that never returns* (or always throws) returns `never`. `void` is something that can be assigned (without `strictNullChecking`) but `never` can `never` be assigned to anything other than `never`.
+A function that *returns* nothing returns a Unit `void`. However, a function *that never returns* (or always throws) returns `never`. `void` is something that can be assigned (without `strictNullChecking`) but `never` can `never` be assigned to anything other than `never`.
 
 <!--
 PR: https://github.com/Microsoft/TypeScript/pull/8652

--- a/docs/types/type-assertion.md
+++ b/docs/types/type-assertion.md
@@ -29,7 +29,7 @@ var foo: any;
 var bar = <string> foo; // bar is now of type "string"
 ```
 
-However there is an ambiguity in the language grammar when using `<foo>` style assertions in JSX:
+However, there is an ambiguity in the language grammar when using `<foo>` style assertions in JSX:
 
 ```ts
 var foo = <string>bar;
@@ -39,10 +39,10 @@ var foo = <string>bar;
 Therefore it is now recommended that you just use `as foo` for consistency.
 
 ### Type Assertion vs. Casting
-The reason why it's not called "type casting" is that *casting* generally implies some sort of runtime support. However *type assertions* are purely a compile time construct and a way for you to provide hints to the compiler on how you want your code to be analyzed.
+The reason why it's not called "type casting" is that *casting* generally implies some sort of runtime support. However, *type assertions* are purely a compile time construct and a way for you to provide hints to the compiler on how you want your code to be analyzed.
 
 ### Assertion considered harmful
-In many cases assertion will allow you to easily migrate legacy code (and even copy paste other code samples into your codebase), however you should be careful with your use of assertions. Take our original code as a sample, the compiler will not protect you from forgetting to *actually add the properties you promised*:
+In many cases assertion will allow you to easily migrate legacy code (and even copy paste other code samples into your codebase). However, you should be careful with your use of assertions. Take our original code as a sample, the compiler will not protect you from forgetting to *actually add the properties you promised*:
 
 ```ts
 interface Foo {
@@ -90,7 +90,7 @@ function handler (event: Event) {
 }
 ```
 
-However the following is most likely an error and TypeScript will complain as shown despite the user's type assertion:
+However, the following is most likely an error and TypeScript will complain as shown despite the user's type assertion:
 
 ```ts
 function handler(event: Event) {

--- a/docs/types/type-compatibility.md
+++ b/docs/types/type-compatibility.md
@@ -276,7 +276,7 @@ let y: Empty<string>;
 x = y;  // okay, y matches structure of x
 ```
 
-However if `T` is used, it will play a role in compatibility based on its *instantiation* as shown below:
+However, if `T` is used, it will play a role in compatibility based on its *instantiation* as shown below:
 
 ```ts
 interface NotEmpty<T> {

--- a/docs/types/type-inference.md
+++ b/docs/types/type-inference.md
@@ -139,7 +139,7 @@ Types do not flow into the function parameters if it cannot be inferred from an 
 const foo = (a,b) => { /* do something */ };
 ```
 
-However if `foo` was typed the function parameters type can be inferred (`a`,`b` are both inferred to be of type `number` in the example below).
+However, if `foo` was typed the function parameters type can be inferred (`a`,`b` are both inferred to be of type `number` in the example below).
 
 ```ts
 type TwoNumberFunction = (a: number, b: number) => void;

--- a/docs/types/type-system.md
+++ b/docs/types/type-system.md
@@ -148,7 +148,7 @@ function log(message): void {
 ```
 
 ## Generics
-Many algorithms and data structures in computer science do not depend on the *actual type* of the object. However you still want to enforce a constraint between various variables. A simple toy example is a function that takes a list of items and returns a reversed list of items. The constraint here is between what is passed in to the function and what is returned by the function:
+Many algorithms and data structures in computer science do not depend on the *actual type* of the object. However, you still want to enforce a constraint between various variables. A simple toy example is a function that takes a list of items and returns a reversed list of items. The constraint here is between what is passed in to the function and what is returned by the function:
 
 ```ts
 function reverse<T>(items: T[]): T[] {

--- a/docs/why-typescript.md
+++ b/docs/why-typescript.md
@@ -14,7 +14,7 @@ Types have proven ability to enhance code quality and understandability. Large t
 * Types increase your agility when doing refactoring. *It's better for the compiler to catch errors than to have things fail at runtime*.
 * Types are one of the best forms of documentation you can have. *The function signature is a theorem and the function body is the proof*.
 
-However types have a way of being unnecessarily ceremonious. TypeScript is very particular about keeping the barrier to entry as low as possible. Here's how:
+However, types have a way of being unnecessarily ceremonious. TypeScript is very particular about keeping the barrier to entry as low as possible. Here's how:
 
 ### Your JavaScript is TypeScript
 TypeScript provides compile time type safety for your JavaScript code. This is no surprise given its name. The great thing is that the types are completely optional. Your JavaScript code `.js` file can be renamed to a `.ts` file and TypeScript will still give you back valid `.js` equivalent to the original JavaScript file. TypeScript is *intentionally* and strictly a superset of JavaScript with optional Type checking.
@@ -31,7 +31,7 @@ foo = '456'; // Error: cannot assign `string` to `number`
 This type inference is well motivated. If you do stuff like shown in this example, then, in the rest of your code, you cannot be certain that `foo` is a `number` or a `string`. Such issues turn up often in large multi-file code bases. We will deep dive into the type inference rules later.
 
 ### Types can be Explicit
-As we've mentioned before, TypeScript will infer as much as it can safely, however you can use annotations to:
+As we've mentioned before, TypeScript will infer as much as it can safely. However, you can use annotations to:
 1. Help along the compiler, and more importantly document stuff for the next developer who has to read your code (that might be future you!).
 1. Enforce that what the compiler sees, is what you thought it should see. That is your understanding of the code matches an algorithmic analysis of the code (done by the compiler).
 


### PR DESCRIPTION
Went down the rabbit hole of adding commas after conjunctive adverbs like "However". There are likely more but here's the grammatical reasoning behind it.

> Conjunctive adverbs are often used as introductory terms; in this case, these words should be followed by a comma for clarity: Therefore, all of the test animals were re-examined.

[Source](https://www.aje.com/en/arc/editing-tip-commas-conjunctive-adverbs/)