### PR TITLE
Remove the note about generators being unavailable

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -1,7 +1,5 @@
 ## Generators
 
-> NOTE: You cannot use generators in TypeScript in a meaningful way (the ES5 emitter is in progress). However, that will change soon so we still have this chapter.
-
 `function *` is the syntax used to create a *generator function*. Calling a generator function returns a *generator object*. The generator object just follows the [iterator][iterator] interface (i.e. the `next`, `return` and `throw` functions). 
 
 There are two key motivations behind generator functions: 


### PR DESCRIPTION
Generators can be transpiled to ES5 since TS 2.3: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generators