### PR TITLE
Modify wording of never assignability

### DIFF
--- a/docs/types/never.md
+++ b/docs/types/never.md
@@ -15,7 +15,7 @@ Of course you can use this annotation yourself as well
 let foo: never; // Okay
 ```
 
-However, `never` *can only ever be assigned to another never*. e.g.
+However, *only `never` can be assigned to another never*. e.g.
 
 ```ts
 let foo: never = 123; // Error: Type number is not assignable to never


### PR DESCRIPTION
The original statement, "never can only ever be assigned to another never," implies the following is not allowed:

```ts
let bar: never;
let foo: number = bar // statement implies this is not allowed
```