### PR TITLE
Fix link to truthy Javascript chapter

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,7 +9,7 @@
   * [this](docs/javascript/this.md)
   * [Closure](docs/javascript/closure.md)
   * [Number](docs/javascript/number.md)
-  * [Truthy](docs/tips/truthy.md)
+  * [Truthy](docs/javascript/truthy.md)
 * [Future JavaScript Now](docs/future-javascript.md)
   * [Classes](docs/classes.md)
     * [Classes Emit](docs/classes-emit.md)


### PR DESCRIPTION
It got moved in e734f5146d20dcef8ba624e5b8710eda12526b6c but the link
wasn't updated.