### PR TITLE
Update lazyObjectLiteralInitialization.md

### DIFF
--- a/docs/tips/lazyObjectLiteralInitialization.md
+++ b/docs/tips/lazyObjectLiteralInitialization.md
@@ -77,5 +77,4 @@ foo.bas = "Hello World";
 
 // later in the codebase:
 foo.bar = 'Hello Stranger'; // Error: You probably misspelled `bas` as `bar`, cannot assign string to number
-}
 ```


### PR DESCRIPTION
Hi,

It seems there's a misplaced closing bracket in the code sample in the `lazyObjectLiteralInitialization.md` file.

This PR fix code typo.