### PR TITLE
Fix example in iterators section

### DIFF
--- a/docs/iterators.md
+++ b/docs/iterators.md
@@ -46,7 +46,8 @@ class Frame implements Iterator<Component> {
       }
     } else {
       return {
-        done: true
+        done: true,
+        value: null
       }
     }
   }
@@ -58,7 +59,7 @@ let iteratorResult1 = frame.next(); //{ done: false, value: Component { name: 't
 let iteratorResult2 = frame.next(); //{ done: false, value: Component { name: 'bottom' } }
 let iteratorResult3 = frame.next(); //{ done: false, value: Component { name: 'left' } }
 let iteratorResult4 = frame.next(); //{ done: false, value: Component { name: 'right' } }
-let iteratorResult5 = frame.next(); //{ done: true }
+let iteratorResult5 = frame.next(); //{ done: true, value: null }
 
 //It is possible to access the value of iterator result via the value property:
 let component = iteratorResult1.value; //Component { name: 'top' }


### PR DESCRIPTION
## Context

I noticed when defining `frame.next()` it returns a type error since it can return `{ done : true }` when the type requires `{ done: boolean, value: T }`