### PR TITLE
The result of a yield operator always has type any

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -79,7 +79,7 @@ Execution resumed
 
 > So essentially the execution of the generator function is controllable by the generator object.
 
-Our communication using the generator has been mostly one way with the generator returning values for the iterator. One extremely powerful feature of generators in JavaScript is that they allow two way communications!
+Our communication using the generator has been mostly one way with the generator returning values for the iterator. One extremely powerful feature of generators in JavaScript is that they allow two way communications (with caveats).
 
 * you can control the resulting value of the `yield` expression using `iterator.next(valueToInject)`
 * you can throw an exception at the point of the `yield` expression using `iterator.throw(error)`
@@ -88,7 +88,7 @@ The following example demonstrates `iterator.next(valueToInject)`:
 
 ```ts
 function* generator() {
-    var bar = yield 'foo';
+    const bar = yield 'foo'; // bar may be *any* type
     console.log(bar); // bar!
 }
 
@@ -99,6 +99,10 @@ console.log(foo.value); // foo
 // Resume execution injecting bar
 const nextThing = iterator.next('bar');
 ```
+
+Since `yield` returns the parameter passed to the iterator's `next` function, and all iterators' `next` functions accept a parameter of any type, TypeScript will always assign the `any` type to the result of the `yield` operator (`bar` above).
+You are on your own to coerce the result to the type you expect, and ensure that only values of that type are passed to next (such as by scaffolding an additional type-enforcement layer that calls `next` for you.)
+If strong typing is important to you, you may want to avoid two-way communication altogether, as well as packages that rely heavily on it (e.g., redux-saga).
 
 The following example demonstrates `iterator.throw(error)`:
 

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -101,8 +101,8 @@ const nextThing = iterator.next('bar');
 ```
 
 Since `yield` returns the parameter passed to the iterator's `next` function, and all iterators' `next` functions accept a parameter of any type, TypeScript will always assign the `any` type to the result of the `yield` operator (`bar` above).
-You are on your own to coerce the result to the type you expect, and ensure that only values of that type are passed to next (such as by scaffolding an additional type-enforcement layer that calls `next` for you.)
-If strong typing is important to you, you may want to avoid two-way communication altogether, as well as packages that rely heavily on it (e.g., redux-saga).
+
+> You are on your own to coerce the result to the type you expect, and ensure that only values of that type are passed to next (such as by scaffolding an additional type-enforcement layer that calls `next` for you.) If strong typing is important to you, you may want to avoid two-way communication altogether, as well as packages that rely heavily on it (e.g., redux-saga).
 
 The following example demonstrates `iterator.throw(error)`:
 


### PR DESCRIPTION
Document the problems with two-way communication in generators, as the next function accepts a parameter of any type and so the result of the yield operator is always of type any.