### PR TITLE
add @types/enzyme-adapter-react-16

### DIFF
--- a/docs/testing/jest.md
+++ b/docs/testing/jest.md
@@ -122,7 +122,7 @@ test('basic again', async () => {
 
 Enzyme allows you to test react components with dom support. There are three steps to setting up enzyme:
 
-1. Install enzyme, types for enzyme, a better snapshot serializer for enzyme, enzyme-adapter-react for your react version `npm i enzyme @types/enzyme enzyme-to-json enzyme-adapter-react-16 -D`
+1. Install enzyme, types for enzyme, a better snapshot serializer for enzyme, enzyme-adapter-react for your react version `npm i enzyme @types/enzyme enzyme-to-json enzyme-adapter-react-16 @types/enzyme-adapter-react-16 -D`
 2. Add `"snapshotSerializers"` and `"setupTestFrameworkScriptFile"` to your `jest.config.js`:  
 
 ```js


### PR DESCRIPTION
If you don't install `@types/enzyme-adapter-react-16 `, TypeScript will show an error: `Only a void function can be called with the 'new' keyword` in `setupEnzyme.ts` file.

https://stackoverflow.com/questions/54907401/enzyme-ts2350-only-a-void-function-can-be-called-with-the-new-keyword