### PR TITLE
fix code block indentation

### DIFF
--- a/docs/project/external-modules.md
+++ b/docs/project/external-modules.md
@@ -69,6 +69,7 @@ import { someVar as aDifferentName } from './foo';
 ```
 
 * Import everything from a module into a name with `import * as` e.g.
+
 ```js
 // file `bar.ts`
 import * as foo from './foo';


### PR DESCRIPTION
Without the newline, the code is part of li element and is indented from left.
![image](https://user-images.githubusercontent.com/290157/55552325-5f692c00-56dd-11e9-8f75-ffb48215a64a.png)
