### PR TITLE
Extended TypedEvent example class

### DIFF
--- a/docs/tips/typed-event.md
+++ b/docs/tips/typed-event.md
@@ -69,8 +69,10 @@ export class TypedEvent<T> {
     this.listeners.forEach((listener) => listener(event));
 
     /** Clear the `once` queue */
-    this.listenersOncer.forEach((listener) => listener(event));
-    this.listenersOncer = [];
+    if (this.listenersOncer.length > 0) {
+      this.listenersOncer.forEach((listener) => listener(event));
+      this.listenersOncer = [];
+    }
   }
 
   pipe = (te: TypedEvent<T>): Disposable => {


### PR DESCRIPTION
Added additional condition to `emit` method where the `listenersOncer` will be processed only if there is something available.
It helps with performance. In this case it won't assign on each `emit` call the empty array.