### PR TITLE
Freshness typos

### DIFF
--- a/code/types/freshness/freshness.ts
+++ b/code/types/freshness/freshness.ts
@@ -1,42 +1,94 @@
 export var foo = 123;
 
-
 module first {
-    function logName(something: { name: string }) {
-        console.log(something.name);
-    }
+	function logName(something: { name: string }) {
+		console.log(something.name);
+	}
 
-    var person = { name: 'matt', job: 'being awesome' };
-    var animal = { name: 'cow', diet: 'vegan, but has milk of own species' };
-    var random = { note: `I don't have a name property` };
+	var person = { name: 'matt', job: 'being awesome' };
+	var animal = { name: 'cow', diet: 'vegan, but has milk of own species' };
+	var random = { note: `I don't have a name property` };
 
-    logName(person); // okay
-    logName(animal); // okay
-    logName(random); // Error : property `name` is missing
+	logName(person); // okay
+	logName(animal); // okay
+	logName(random); // Error : property `name` is missing
 }
 
 module second {
-    function logName(something: { name: string }) {
-        console.log(something.name);
-    }
+	function logName(something: { name: string }) {
+		console.log(something.name);
+	}
 
-    logName({ name: 'matt' }); // okay
-    logName({ name: 'matt', job: 'being awesome' }); // Error: object literals must only specify known properties. `job` is excessive here.
+	logName({ name: 'matt' }); // okay
+	logName({ name: 'matt', job: 'being awesome' }); // Error: object literals must only specify known properties. `job` is excessive here.
 }
 
+module third {
+	function logIfHasName(something: { name?: string }) {
+		if (something.name) {
+			console.log(something.name);
+		}
+	}
+	var person = { name: 'matt', job: 'being awesome' };
+	var animal = { name: 'cow', diet: 'vegan, but has milk of own species' };
 
-module second {
-    function logIfHasName(something: { name?: string }) {
-        if (something.name) {
-            console.log(something.name);
-        }
-    }
-    var person = { name: 'matt', job: 'being awesome' };
-    var animal = { name: 'cow', diet: 'vegan, but has milk of own species' };
-    var random = { note: `I don't have a name property` };
+	logIfHasName(person); // okay
+	logIfHasName(animal); // okay
+	logIfHasName({ neme: 'I just misspelled name to neme' }); // Error: object literals must only specify known properties. `neme` is excessive here.
+}
 
-    logIfHasName(person); // okay
-    logIfHasName(animal); // okay
-    logIfHasName(random); // okay
-    logIfHasName({neme: 'I just misspelled name to neme'}); // Error: object literals must only specify known properties. `neme` is excessive here.
+module fourth {
+	var x: { foo: number; [x: string]: any };
+	x = { foo: 1, baz: 2 }; // Ok, `baz` matched by index signature
+}
+
+module fifth {
+	// Assuming
+	interface State {
+		foo: string;
+		bar: string;
+	}
+
+	class MyComponent {
+		state: any;
+
+		setState(state: State) {
+			/* ... */
+		}
+
+		doSomething() {
+			// You want to do:
+			this.setState({ foo: 'Hello' }); // Error: missing property bar
+
+			// But because state contains both `foo` and `bar` TypeScript would force you to do:
+			this.setState({ foo: 'Hello', bar: this.state.bar });
+		}
+	}
+}
+
+module sixth {
+	// Assuming
+	interface State {
+		foo?: string;
+		bar?: string;
+	}
+
+	class MyComponent {
+		state: any;
+
+		setState(state: State) {
+			/* ... */
+		}
+
+		doSomething() {
+			// You want to do:
+			this.setState({ foo: 'Hello' }); // Yay works fine!
+
+			// Because of freshness it's protected against typos as well!
+			this.setState({ foos: 'Hello' }); // Error: Objects may only specify known properties
+
+			// And still type checked
+			this.setState({ foo: 123 }); // Error: Cannot assign number to a string
+		}
+	}
 }

--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -78,7 +78,7 @@ interface State {
 this.setState({foo: "Hello"}); // Error: missing property bar
 
 // But because state contains both `foo` and `bar` TypeScript would force you to do: 
-this.setState({foo: "Hello", bar: this.state.bar}};
+this.setState({foo: "Hello", bar: this.state.bar});
 ```
 
 Using the idea of freshness you would mark all the members as optional and *you still get to catch typos*!: 
@@ -94,8 +94,8 @@ interface State {
 this.setState({foo: "Hello"}); // Yay works fine!
 
 // Because of freshness it's protected against typos as well!
-this.setState({foos: "Hello"}}; // Error: Objects may only specify known properties
+this.setState({foos: "Hello"}); // Error: Objects may only specify known properties
 
 // And still type checked
-this.setState({foo: 123}}; // Error: Cannot assign number to a string
+this.setState({foo: 123}); // Error: Cannot assign number to a string
 ```

--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -70,8 +70,8 @@ x = { foo: 1, baz: 2 };  // Ok, `baz` matched by index signature
 ```ts
 // Assuming
 interface State {
-  foo: string;
-  bar: string;
+    foo: string;
+    bar: string;
 }
 
 // You want to do: 
@@ -86,8 +86,8 @@ Using the idea of freshness you would mark all the members as optional and *you 
 ```ts
 // Assuming
 interface State {
-  foo?: string;
-  bar?: string;
+    foo?: string;
+    bar?: string;
 }
 
 // You want to do: 


### PR DESCRIPTION
The last examples in Freshness had incorrect closing parentheses. While fixing them I noticed those same examples were missing on `/code`, so I added them inside a fake class to allow the editor to detect future errors.