### PR TITLE
Fix Nominal Typing for TypeScript 3.6.2 by forcing enums to be string enums

### DIFF
--- a/docs/tips/nominalTyping.md
+++ b/docs/tips/nominalTyping.md
@@ -45,11 +45,11 @@ This is demonstrated below where the structure of the types is just a string:
 
 ```ts
 // FOO
-enum FooIdBrand {}
+enum FooIdBrand { _ = "" };
 type FooId = FooIdBrand & string;
 
 // BAR
-enum BarIdBrand {}
+enum BarIdBrand  { _ = "" };
 type BarId = BarIdBrand & string;
 
 /**
@@ -71,6 +71,8 @@ var str: string;
 str = fooId;
 str = barId;
 ```
+
+Note how the brand enums,  ``FooIdBrand`` and ``BarIdBrand`` above, each have single member (_) that maps to the empty string, as specified by ``{ _ = "" }``. This forces TypeeScript to infer that these are string-based enums, with values of type ``string``, and not enums with values of type ``number``.  This is necessary because TypeScript infers an empty enum (``{}``) to be a numeric enum, and as of TypeScript 3.6.2 the intersection of a numeric ``enum`` and ``string`` is ``never``.
 
 ## Using Interfaces
 


### PR DESCRIPTION
Addresses: https://github.com/basarat/typescript-book/issues/521
Uses technique from: https://github.com/microsoft/TypeScript/issues/32891

Also note: This "& string" that remains in this code sample appears to do nothing as of TypeScript 3.6.2, but presumably should be kept for backwards compat.