### PR TITLE
Fix typo in "Null vs. Undefined" section

### DIFF
--- a/docs/javascript/null-undefined.md
+++ b/docs/javascript/null-undefined.md
@@ -119,7 +119,7 @@ JSON.stringify({willStay: null, willBeGone: undefined}); // {"willStay":null}
 
 As a result, JSON-based databases may support `null` values but not `undefined` values. Since attributes set to `null` are encoded, you can transmit the intent to clear an attribute by setting its value to `null` before encoding and transmitting the object to a remote store.
 
-Setting attribute values to undefined can save of storage and transmission costs, as the attribute names will not be encoded. However, this can complicate the semantics of clearing values vs. absent values.
+Setting attribute values to undefined can save on storage and transmission costs, as the attribute names will not be encoded. However, this can complicate the semantics of clearing values vs. absent values.
 
 ### Final thoughts
 TypeScript team doesn't use `null` : [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined) and it hasn't caused any problems. Douglas Crockford thinks [`null` is a bad idea](https://www.youtube.com/watch?v=PSGEjv3Tqo0&feature=youtu.be&t=9m21s) and we should all just use `undefined`.


### PR DESCRIPTION
"can save **_of_** storage and transmission costs" > "can save **_on_** storage and transmission costs"