### PR TITLE
Up to date jest.md

### DIFF
--- a/docs/testing/jest.md
+++ b/docs/testing/jest.md
@@ -120,7 +120,7 @@ module.exports = {
 
   // Setup Enzyme
   "snapshotSerializers": ["enzyme-to-json/serializer"],
-  "setupTestFrameworkScriptFile": "<rootDir>/src/setupEnzyme.ts",
+  "setupFilesAfterEnv": ["<rootDir>/src/setupEnzyme.ts"],
 }
 ```
 
@@ -128,7 +128,7 @@ module.exports = {
 
 ```js
 import { configure } from 'enzyme';
-import * as EnzymeAdapter from 'enzyme-adapter-react-16';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
 configure({ adapter: new EnzymeAdapter() });
 ```
 


### PR DESCRIPTION
I've just setting up test for my projects and there was a message about `"setupTestFrameworkScriptFile" is depercated`
![Screen Shot 2019-10-29 at 12 12 46 PM](https://user-images.githubusercontent.com/13422799/67758060-a043dc00-fa45-11e9-8a2b-900a52419d3d.png)

Additinally `import * as EnzymeAdapter from 'enzyme-adapter-react-16';` do not working too, need to use default import
![Screen Shot 2019-10-29 at 12 14 32 PM](https://user-images.githubusercontent.com/13422799/67758086-ac2f9e00-fa45-11e9-862b-1adeaa6ca3d5.png)
