### PR TITLE
Update Code Example in "Use case: Ensure Import"

### DIFF
--- a/docs/project/external-modules.md
+++ b/docs/project/external-modules.md
@@ -297,6 +297,6 @@ import bar = require('./bar');
 import bas = require('./bas');
 const ensureImport: any =
     foo
-    || bar
-    || bas;
+    && bar
+    && bas;
 ```


### PR DESCRIPTION
In the "Use case: Ensure Import" section code example, ensure that all of these are imported by using `&&` instead of `||`.