### PR TITLE
Fix stale path to type-assertion.md

### DIFF
--- a/docs/jsx/react.md
+++ b/docs/jsx/react.md
@@ -197,7 +197,7 @@ class FocusingInput extends React.Component<{ value: string, onChange: (value: s
 
 ### Type Assertions
 
-Use `as Foo` syntax for type assertions as we [mentioned before](./type-assertion.md#as-foo-vs-foo).
+Use `as Foo` syntax for type assertions as we [mentioned before](../types/type-assertion.md#as-foo-vs-foo).
 
 ## Default Props
 


### PR DESCRIPTION
Hello. 🌹 

I've found a dead link in [this section](https://basarat.gitbooks.io/typescript/docs/jsx/react.html#type-assertions) and fixed it to be a link to [this section](https://basarat.gitbooks.io/typescript/docs/types/type-assertion.html#as-foo-vs-foo), the place it used to link to.
