### PR TITLE
Removes quantifier from Jest's `transform` regex

### DIFF
--- a/docs/testing/jest.md
+++ b/docs/testing/jest.md
@@ -35,7 +35,7 @@ module.exports = {
     "**/?(*.)+(spec|test).+(ts|tsx|js)"
   ],
   "transform": {
-    "^.+\\.(ts|tsx)?$": "ts-jest"
+    "^.+\\.(ts|tsx)$": "ts-jest"
   },
 }
 ```


### PR DESCRIPTION
Hello, first-time contributor here.

This commit removes a regex quantifier from suggested Jest's `transform` matcher. This quantifier (the character `?`) would match files that otherwise shouldn't be matched by Jest.

As you can see in the screenshot below, the quantifier makes the whole extension optional:

[![](https://user-images.githubusercontent.com/673884/69070423-e1a52700-0a06-11ea-8ec3-407bdd5f141e.png)](https://user-images.githubusercontent.com/673884/69070423-e1a52700-0a06-11ea-8ec3-407bdd5f141e.png)