### PR TITLE
rename 'globals.d.ts' to 'global.d.ts'

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -32,7 +32,7 @@
   * [Declaration Spaces](docs/project/declarationspaces.md)
   * [Modules](docs/project/modules.md)
     * [File Module Details](docs/project/external-modules.md)
-    * [globals.d.ts](docs/project/globals.md)
+    * [global.d.ts](docs/project/globals.md)
   * [Namespaces](docs/project/namespaces.md)
   * [Dynamic Import Expressions](docs/project/dynamic-import-expressions.md)
 * [Node.js QuickStart](docs/quick/nodejs.md)

--- a/docs/project/external-modules.md
+++ b/docs/project/external-modules.md
@@ -179,7 +179,7 @@ You can declare a module *globally* for your project by using `declare module 's
 
 e.g.
 ```ts
-// globals.d.ts
+// global.d.ts
 declare module 'foo' {
   // Some variable declarations
   export var bar: number; /*sample*/

--- a/docs/project/globals.md
+++ b/docs/project/globals.md
@@ -1,10 +1,10 @@
-# globals.d.ts
+# global.d.ts
 
 We discussed *global* vs. *file* modules when covering [projects](./modules.md) and recommended using file based modules and not polluting the global namespace.
 
-Nevertheless, if you have beginning TypeScript developers you can give them a `globals.d.ts` file to put interfaces / types in the global namespace to make it easy to have some *types* just *magically* available for consumption in *all* your TypeScript code.
+Nevertheless, if you have beginning TypeScript developers you can give them a `global.d.ts` file to put interfaces / types in the global namespace to make it easy to have some *types* just *magically* available for consumption in *all* your TypeScript code.
 
 > For any code that is going to generate *JavaScript* we highly recommend using *file modules*.
 
-* `globals.d.ts` is great for adding extensions to `lib.d.ts` if you need to.
+* `global.d.ts` is great for adding extensions to `lib.d.ts` if you need to.
 * It's good for quick `declare module "some-library-you-dont-care-to-get-defs-for";` when doing JS to TS migrations.

--- a/docs/types/ambient/d.ts.md
+++ b/docs/types/ambient/d.ts.md
@@ -10,7 +10,7 @@ declare var foo: any;
 foo = 123; // allowed
 ```
 
-You have the option of putting these declarations in a `.ts` file or in a `.d.ts` file. We highly recommend that in your real world projects you use a separate `.d.ts` (start with one called something like `globals.d.ts` or `vendor.d.ts`).
+You have the option of putting these declarations in a `.ts` file or in a `.d.ts` file. We highly recommend that in your real world projects you use a separate `.d.ts` (start with one called something like `global.d.ts` or `vendor.d.ts`).
 
 If a file has the extension `.d.ts` then each root level definition must have the `declare` keyword prefixed to it. This helps make it clear to the author that there will be *no code emitted by TypeScript*. The author needs to ensure that the declared item will exist at runtime.
 

--- a/docs/types/lib.d.ts.md
+++ b/docs/types/lib.d.ts.md
@@ -62,7 +62,7 @@ There is a good reason for using *interfaces* for these globals. It allows you t
 
 ### Modifying Native Types
 
-Since an `interface` in TypeScript is open ended this means that you can just add members to the interfaces declared in `lib.d.ts` and TypeScript will pick up on the additions. Note that you need to make these changes in a [*global module*](../project/modules.md) for these interfaces to be associated with `lib.d.ts`. We even recommend creating a special file called [`globals.d.ts`](../project/globals.md) for this purpose.
+Since an `interface` in TypeScript is open ended this means that you can just add members to the interfaces declared in `lib.d.ts` and TypeScript will pick up on the additions. Note that you need to make these changes in a [*global module*](../project/modules.md) for these interfaces to be associated with `lib.d.ts`. We even recommend creating a special file called [`global.d.ts`](../project/globals.md) for this purpose.
 
 Here are a few example cases where we add stuff to `window`, `Math`, `Date`:
 

--- a/docs/types/migrating.md
+++ b/docs/types/migrating.md
@@ -98,7 +98,7 @@ import * as $ from "jquery";
 
 # External non js resources
 
-You can even allow import of any file e.g. `.css` files (if you are using something like webpack style loaders or css modules) with a simple `*` style declaration (ideally in a [`globals.d.ts` file](../project/globals.md)): 
+You can even allow import of any file e.g. `.css` files (if you are using something like webpack style loaders or css modules) with a simple `*` style declaration (ideally in a [`global.d.ts` file](../project/globals.md)): 
 
 ```ts
 declare module "*.css";


### PR DESCRIPTION
I think you want to use `global.d.ts` for putting interfaces / types in the global namespace.