### PR TITLE
fix: numbered list typo

### DIFF
--- a/docs/classes-emit.md
+++ b/docs/classes-emit.md
@@ -52,7 +52,7 @@ var __extends = this.__extends || function (d, b) {
 ```
 Here `d` refers to the derived class and `b` refers to the base class. This function does two things:
 1. copies the static members of the base class onto the child class i.e. `for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];`
-1. sets up the child class function's prototype to optionally lookup members on the parent's `proto` i.e. effectively `d.prototype.__proto__ = b.prototype`
+2. sets up the child class function's prototype to optionally lookup members on the parent's `proto` i.e. effectively `d.prototype.__proto__ = b.prototype`
 
 People rarely have trouble understanding 1, but many people struggle with 2. So an explanation is in order.
 


### PR DESCRIPTION
The chapter on _Classes Emit_ mentions the "two things" that the `__extends` function does. Both items on the list are labeled `1.`
<img width="758" alt="Screen Shot 2020-01-12 at 17 31 02" src="https://user-images.githubusercontent.com/2840641/72226648-615ff580-3561-11ea-96e3-6151c7edfd62.png">
