### PR TITLE
Fix numbered list rendering

### DIFF
--- a/docs/why-typescript.md
+++ b/docs/why-typescript.md
@@ -32,6 +32,7 @@ This type inference is well motivated. If you do stuff like shown in this exampl
 
 ### Types can be Explicit
 As we've mentioned before, TypeScript will infer as much as it can safely. However, you can use annotations to:
+
 1. Help along the compiler, and more importantly document stuff for the next developer who has to read your code (that might be future you!).
 1. Enforce that what the compiler sees, is what you thought it should see. That is your understanding of the code matches an algorithmic analysis of the code (done by the compiler).
 


### PR DESCRIPTION
As written, this list doesn't render as bullets, and instead collapses into a single paragraph. This change breaks the list into its own paragraph so that it can be parsed as such.