### PR TITLE
Fix nesting of code blocks under lists

### DIFF
--- a/docs/testing/jest.md
+++ b/docs/testing/jest.md
@@ -71,25 +71,25 @@ Add `package.json`:
 
 * For a file `foo.ts`:
 
-```js
-export const sum
-  = (...a: number[]) =>
-    a.reduce((acc, val) => acc + val, 0);
-```
+    ```js
+    export const sum
+      = (...a: number[]) =>
+        a.reduce((acc, val) => acc + val, 0);
+    ```
 
 * A simple `foo.test.ts`:
 
-```js
-import { sum } from '../foo';
+    ```js
+    import { sum } from '../foo';
 
-test('basic', () => {
-  expect(sum()).toBe(0);
-});
+    test('basic', () => {
+      expect(sum()).toBe(0);
+    });
 
-test('basic again', () => {
-  expect(sum(1, 2)).toBe(3);
-});
-```
+    test('basic again', () => {
+      expect(sum(1, 2)).toBe(3);
+    });
+    ```
 
 Notes:
 
@@ -119,81 +119,81 @@ Enzyme allows you to test react components with dom support. There are three ste
 1. Install enzyme, types for enzyme, a better snapshot serializer for enzyme, enzyme-adapter-react for your react version `npm i enzyme @types/enzyme enzyme-to-json enzyme-adapter-react-16 -D`
 2. Add `"snapshotSerializers"` and `"setupTestFrameworkScriptFile"` to your `jest.config.js`:  
 
-```js
-module.exports = {
-  // OTHER PORTIONS AS MENTIONED BEFORE
+    ```js
+    module.exports = {
+      // OTHER PORTIONS AS MENTIONED BEFORE
 
-  // Setup Enzyme
-  "snapshotSerializers": ["enzyme-to-json/serializer"],
-  "setupFilesAfterEnv": ["<rootDir>/src/setupEnzyme.ts"],
-}
-```
+      // Setup Enzyme
+      "snapshotSerializers": ["enzyme-to-json/serializer"],
+      "setupFilesAfterEnv": ["<rootDir>/src/setupEnzyme.ts"],
+    }
+    ```
 
 3. Create `src/setupEnzyme.ts` file.
 
-```js
-import { configure } from 'enzyme';
-import EnzymeAdapter from 'enzyme-adapter-react-16';
-configure({ adapter: new EnzymeAdapter() });
-```
+    ```js
+    import { configure } from 'enzyme';
+    import EnzymeAdapter from 'enzyme-adapter-react-16';
+    configure({ adapter: new EnzymeAdapter() });
+    ```
 
 Now here is an example react component and test:
 
 * `checkboxWithLabel.tsx`:
 
-```ts
-import * as React from 'react';
+    ```ts
+    import * as React from 'react';
 
-export class CheckboxWithLabel extends React.Component<{
-  labelOn: string,
-  labelOff: string
-}, {
-    isChecked: boolean
-  }> {
-  constructor(props) {
-    super(props);
-    this.state = { isChecked: false };
-  }
+    export class CheckboxWithLabel extends React.Component<{
+      labelOn: string,
+      labelOff: string
+    }, {
+        isChecked: boolean
+      }> {
+      constructor(props) {
+        super(props);
+        this.state = { isChecked: false };
+      }
 
-  onChange = () => {
-    this.setState({ isChecked: !this.state.isChecked });
-  }
+      onChange = () => {
+        this.setState({ isChecked: !this.state.isChecked });
+      }
 
-  render() {
-    return (
-      <label>
-        <input
-          type="checkbox"
-          checked={this.state.isChecked}
-          onChange={this.onChange}
-        />
-        {this.state.isChecked ? this.props.labelOn : this.props.labelOff}
-      </label>
-    );
-  }
-}
+      render() {
+        return (
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.isChecked}
+              onChange={this.onChange}
+            />
+            {this.state.isChecked ? this.props.labelOn : this.props.labelOff}
+          </label>
+        );
+      }
+    }
 
-```
+    ```
 
 * `checkboxWithLabel.test.tsx`:
 
-```ts
-import * as React from 'react';
-import { shallow } from 'enzyme';
-import { CheckboxWithLabel } from './checkboxWithLabel';
+    ```ts
+    import * as React from 'react';
+    import { shallow } from 'enzyme';
+    import { CheckboxWithLabel } from './checkboxWithLabel';
 
-test('CheckboxWithLabel changes the text after click', () => {
-  const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
-  
-  // Interaction demo
-  expect(checkbox.text()).toEqual('Off');
-  checkbox.find('input').simulate('change');
-  expect(checkbox.text()).toEqual('On');
-  
-  // Snapshot demo
-  expect(checkbox).toMatchSnapshot();
-});
-```
+    test('CheckboxWithLabel changes the text after click', () => {
+      const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
+
+      // Interaction demo
+      expect(checkbox.text()).toEqual('Off');
+      checkbox.find('input').simulate('change');
+      expect(checkbox.text()).toEqual('On');
+
+      // Snapshot demo
+      expect(checkbox).toMatchSnapshot();
+    });
+    ```
 
 ## Reasons why we like jest
 


### PR DESCRIPTION
This improves the rendering of code blocks inside lists, by ensuring that the code blocks are treated as children of the list items. This also fixes numbering.