### PR TITLE
fix sample code of index signature

### DIFF
--- a/docs/types/index-signatures.md
+++ b/docs/types/index-signatures.md
@@ -138,13 +138,13 @@ As soon as you have a `string` index signature, all explicit members must also c
 ```ts
 /** Okay */
 interface Foo {
-  [key:string]: number
+  [key:string]: number;
   x: number;
   y: number;
 }
 /** Error */
 interface Bar {
-  [key:string]: number
+  [key:string]: number;
   x: number;
   y: string; // ERROR: Property `y` must be of type number
 }
@@ -154,7 +154,7 @@ This is to provide safety so that any string access gives the same result:
 
 ```ts
 interface Foo {
-  [key:string]: number
+  [key:string]: number;
   x: number;
 }
 let foo: Foo = {x:1,y:2};


### PR DESCRIPTION
Currently, `[key: string]: number` is not reflected on the screen.
Adding a trailing semicolon may eliminate this bug.
Unfortunately, this problem does not occur in the local environment, so it is difficult to verify.
In any case, I think it is better to add a semicolon.

*current screen*

![current](https://user-images.githubusercontent.com/16703337/74504863-e9f2fc80-4f38-11ea-96d0-d58d1c67b792.png)
