### PR TITLE
Fix minor type-o in index-signatures.md

### DIFF
--- a/docs/types/index-signatures.md
+++ b/docs/types/index-signatures.md
@@ -115,7 +115,7 @@ let foo:{ [index:string] : {message: string} } = {};
  */
 /** Ok */
 foo['a'] = { message: 'some message' };
-/** Error: must contain a `message` or type string. You have a typo in `message` */
+/** Error: must contain a `message` of type string. You have a typo in `message` */
 foo['a'] = { messages: 'some message' };
 
 /**


### PR DESCRIPTION
There was just a small typo in this file where an `or` should be an `of`

Thanks for the great descriptions.