### PR TITLE
Augment sample config with es6 module help

### DIFF
--- a/docs/testing/jest.md
+++ b/docs/testing/jest.md
@@ -40,6 +40,8 @@ module.exports = {
 }
 ```
 
+(If your `package.json` file contains `"type": "module"`, which causes Node to assume modules are in es6 format, you can convert the above to es6 format by replacing the top line to `export default { ` .)
+
 Explanation:
 
 * We always recommend having *all* TypeScript files in a `src` folder in your project. We assume this is true and specify this using the `roots` option.


### PR DESCRIPTION
Modules, and their continual evolution, are hell.  Unless tooling gets better at inferring module types, examples will have to account for differing module requirements.  Yuck.  I wish this were a part of JavaScript experience that the TypeScript team had taken a bigger role in improving.