### PR TITLE
updates example of generic jsx arrow function to use `unknown`

### DIFF
--- a/docs/jsx/react.md
+++ b/docs/jsx/react.md
@@ -151,7 +151,7 @@ const foo = <T>(x: T) => x; // ERROR : unclosed `T` tag
 **Workaround**: Use `extends` on the generic parameter to hint the compiler that it's a generic, e.g.:
 
 ```ts
-const foo = <T extends {}>(x: T) => x;
+const foo = <T extends unknown>(x: T) => x;
 ```
 
 ### React Tip: Strongly Typed Refs 


### PR DESCRIPTION
now that `unknown` exists, this is the most desirable way to do things https://github.com/typescript-eslint/typescript-eslint/issues/2191