### PR TITLE
Fix: Replace full stop with question mark

### DIFF
--- a/docs/javascript/null-undefined.md
+++ b/docs/javascript/null-undefined.md
@@ -40,7 +40,7 @@ One exception, root level `undefined` values which we discuss next.
 
 ### Checking for root level undefined
 
-Remember how I said you should use `== null`. Of course you do (cause I just said it ^). Don't use it for root level things. In strict mode if you use `foo` and `foo` is undefined you get a `ReferenceError` **exception** and the whole call stack unwinds.
+Remember how I said you should use `== null`? Of course you do (cause I just said it ^). Don't use it for root level things. In strict mode if you use `foo` and `foo` is undefined you get a `ReferenceError` **exception** and the whole call stack unwinds.
 
 > You should use strict mode ... and in fact the TS compiler will insert it for you if you use modules ... more on those later in the book so you don't have to be explicit about it :)
 


### PR DESCRIPTION
"Remember how I said you should use `== null` " is shorthand for the rhetorical question "Do you remember remember how I said you should use `== null`?", with the question answered in the following sentence. We should therefore add a question mark.