### PR TITLE
fixed documentation scripts

### DIFF
--- a/docs/quick/nodejs.md
+++ b/docs/quick/nodejs.md
@@ -22,7 +22,7 @@ Now just add a `script` target to your `package.json` based on your application 
   "scripts": {
     "start": "npm run build:live",
     "build": "tsc -p .",
-    "build:live": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/index.ts"
+    "build:live": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/index.ts"
   },
 ```
 


### PR DESCRIPTION
```
[nodemon] starting `'ts-node' src/index.ts`
''ts-node'' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
[nodemon] app crashed - waiting for file changes before starting...
```

ts-node command not found.
It didn't work unless it was double quotes.

OS: windows10