### PR TITLE
Change 'extra properties' type from `any` to `unknown`

### DIFF
--- a/docs/types/freshness.md
+++ b/docs/types/freshness.md
@@ -59,7 +59,7 @@ The reason why only object literals are type checked this way is because in this
 A type can include an index signature to explicitly indicate that excess properties are permitted:
 
 ```ts
-var x: { foo: number, [x: string]: any };
+var x: { foo: number, [x: string]: unknown };
 x = { foo: 1, baz: 2 };  // Ok, `baz` matched by index signature
 ```
 


### PR DESCRIPTION
I think this is a much better practice, as it will prevent the developer from doing something like: 

```
function logIfHasName(something: { name?: string, [key: string]: unknown}) {
    if (something.name) {
        console.log(something.name);
        console.log(something.foo.bar); //Object is of type 'unknown'.(2571)
    }
}
```

As opposed to 

```

function logIfHasName2(something: { name?: string, [key: string]: any}) {
    if (something.name) {
        console.log(something.name);
        console.log(something.foo.bar); //is allowed
    }
}
```

https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAGzgcwJLABIEMDOAcrgLYCmAFPnOVABYxhoBciA3omKWQPyv5QATozQAaRAG0A1mQCe-ISIC6rcFLBwA7mAC+ASnYAoRCcQxgiKjTL0RAOi7kDbY6bcQE1ZGTuo0V2gYmB249AG5XNxMPMC8fPwCbILQ7YDg4OwAjXEFwxAB6fIB5TIArMmgzfEQ4CyhZAAcyRAByNQ1tFrsKACYAVgB2AEY9SMQdQwnDUEhYBBR0LDwibh7E2yZWDkdeBWEmcWk5PeVWXDBZfSM3c0tqQPsd5zH3TzhvX3R15JCnCKjTDE4p9-PckvY0hlsrkwgV8jBqrhkKhNGQACZjCY6IA