### PR TITLE
Replace Calibre binaries with official ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 12
       - run: sudo apt update
-      - run: sudo apt install calibre-bin
+      - run: sudo -v && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
       - run: sudo npm install -g gitbook-cli
       - run: gitbook install
       - run: mkdir output


### PR DESCRIPTION
Actions to convert the book to other types was failing. I Managed to get it working again by switching to the official Calibre binaries