### PR TITLE
Remove unnecessary explanations.

### DIFF
--- a/docs/testing/cypress.md
+++ b/docs/testing/cypress.md
@@ -58,18 +58,6 @@ Under the `e2e` folder you now have these files:
     * `/integration`: All your tests.
         * Feel free to create tests under subfolders for better organization e.g. `/someFeatureFolder/something.spec.ts`.
 
-## First test
-* create a file `/cypress/integration/first.ts` with the following contents:
-
-```ts
-describe('google search', () => {
-  it('should work', () => {
-    cy.visit('http://www.google.com');
-    cy.get('#lst-ib').type('Hello world{enter}')
-  });
-});
-```
-
 ## Running in development
 Open the cypress IDE using the following command.
 


### PR DESCRIPTION
## Summary

Test cases described as "first test" can be confusing because they fail.
The first test was already written in the previous item, so I thought I didn't need this item and deleted it.

See: 
https://github.com/basarat/typescript-book/blob/32bbf51fc6327dfa27d166c152187fc58db63a43/docs/testing/cypress.md#first-test