### PR TITLE
making example of enum approach more standalone

### DIFF
--- a/docs/tips/nominalTyping.md
+++ b/docs/tips/nominalTyping.md
@@ -41,16 +41,16 @@ The workaround involves:
 * Creating a *brand* enum.
 * Creating the type as an *intersection* (`&`) of the brand enum + the actual structure.
 
-This is demonstrated below where the structure of the types is just a string:
+This is demonstrated below where the structure of the types is just a number:
 
 ```ts
 // FOO
 enum FooIdBrand { _ = "" };
-type FooId = FooIdBrand & string;
+type FooId = FooIdBrand & number;
 
 // BAR
 enum BarIdBrand  { _ = "" };
-type BarId = BarIdBrand & string;
+type BarId = BarIdBrand & number;
 
 /**
  * Usage Demo
@@ -63,13 +63,14 @@ fooId = barId; // error
 barId = fooId; // error
 
 // Newing up
-fooId = 'foo' as FooId;
-barId = 'bar' as BarId;
+fooId = 12345; //error
+fooId = 12345 as FooId;
+barId = 88888 as BarId;
 
 // Both types are compatible with the base
-var str: string;
-str = fooId;
-str = barId;
+var num: number;
+num = fooId;
+num = barId;
 ```
 
 Note how the brand enums,  ``FooIdBrand`` and ``BarIdBrand`` above, each have single member (`_`) that maps to the empty string, as specified by ``{ _ = "" }``. This forces TypeScript to infer that these are string-based enums, with values of type ``string``, and not enums with values of type ``number``.  This is necessary because TypeScript infers an empty enum (``{}``) to be a numeric enum, and as of TypeScript 3.6.2 the intersection of a numeric ``enum`` and ``string`` is ``never``.


### PR DESCRIPTION
The use of string in both the enum and the structure made it a bit ambiguous whether the two types needed to match or not. The instructions above make it clear, but I figure it's nice to have an example that is unambiguous by itself.

The bit I'm not 100% on is the very last comment in this section, because I found that the IDE would show 'never' as the intersection between `string` enum and `number` but that the behaviour was still ok. So I didn't know if the comment was still valid for other structural types.

The workaround worked great for me anyway though, so thanks for posting this great guide!