### PR TITLE
Remove misconception about what `never` is assignable to. 

### DIFF
--- a/docs/types/never.md
+++ b/docs/types/never.md
@@ -50,8 +50,6 @@ function foo(x: string | number): boolean {
 function fail(message: string): never { throw new Error(message); }
 ```
 
-And because `never` is only assignable to another `never` you can use it for *compile time* exhaustive checks as well. This is covered in the [*discriminated union* section](./discriminated-unions.md).
-
 # Confusion with `void`
 
 As soon as someone tells you that `never` is returned when a function never exits gracefully you intuitively want to think of it as the same as `void`. However, `void` is a Unit. `never` is a falsum.


### PR DESCRIPTION
>And because `never` is only assignable to another `never` 

This isn't true!

`never` _is_ assignable to a number for example, see for yourself. 

```


function myFunction(a: number) {

}


function returnsNever() : never {
    throw new Error(); 
}


const a= returnsNever(); 
myFunction(a); // No type error here!

```

https://www.typescriptlang.org/play?ssl=15&ssc=1&pln=1&pc=1#code/FDBmFcDsGMBcEsD2kAEBbAngMSnJkAKAQwC4VJw0AjAUwCcBKFAbxAF8QxcFkU6bY4OpADOAORoA3egSZlIU+i2ApVKWAAs6iAO7kaegKJ1tdWQG4UwDiGjIRsFEQC8fAUNETpZhpeCYcGB5CIl8UAHpwlDFEdQwABxoUelMUDXoaAEJgIA

See documentation here: 
https://www.typescriptlang.org/docs/handbook/basic-types.html#never

>The never type is a subtype of, and assignable to, every type;