### PR TITLE
Added link to TypeScript Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ All the amazing [contributors](https://github.com/basarat/typescript-book/graphs
 
 ## Share
 Share URL: https://basarat.gitbook.io/typescript/
+
+## Roadmap
+* [TypeScript Roadmap](https://roadmap.sh/typescript)


### PR DESCRIPTION
Hi Basarat,

I came across your repository [typescript-book](https://github.com/basarat/typescript-book) and found it to be a valuable resource for TypeScript enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["TypeScript Roadmap"](https://roadmap.sh/typescript). I took the initiative to submit a ["Pull Request"](https://github.com/basarat/typescript-book/pull/681) adding it a separate roadmap section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz