### PR TITLE
fix: TypeScript's option checking return value should be `noImplicitReturns`

### DIFF
--- a/docs/types/discriminated-unions.md
+++ b/docs/types/discriminated-unions.md
@@ -128,9 +128,9 @@ function area(s: Shape) {
 
 [references-discriminated-union]:https://github.com/Microsoft/TypeScript/pull/9163
 
-### strictNullChecks
+### noImplicitReturns
 
-If using *strictNullChecks* and doing exhaustive checks, TypeScript might complain "not all code paths return a value". You can silence that by simply returning the `_exhaustiveCheck` variable (of type `never`). So:
+If using *noImplicitReturns* and doing exhaustive checks, TypeScript might complain "not all code paths return a value". You can silence that by simply returning the `_exhaustiveCheck` variable (of type `never`). So:
 
 ```ts
 function area(s: Shape) {


### PR DESCRIPTION
This following portion of the documentation is incorrect, [strictNullChecks](https://www.typescriptlang.org/tsconfig/#strictNullChecks) does not have to do with the `"not all code paths return a value"` check, it is [noImplicitReturns](https://www.typescriptlang.org/tsconfig/#noImplicitReturns) that checks this.

> If using _strictNullChecks_ and doing exhaustive checks, TypeScript might complain "not all code paths return a value". You can silence that by simply returning the `_exhaustiveCheck` variable (of type `never`).
https://basarat.gitbook.io/typescript/type-system/discriminated-unions#strictnullchecks

Playground example:
- `strictNullChecks` is off: https://www.typescriptlang.org/play/?strictNullChecks=false#code/JYOwLgpgTgZghgYwgAgMoEcCucooN4BQyxyA1qACYBcyARAM5Y4S0DcRJ9wAXhDSJgC2AI2jsAvgQKhIsRCgBKEBGDggA5gBt8HYuRDU6uFWq0t2JZAHdgFMAAt+Q0VAsl7EYOvtgnIsQSS0uDQ8EjIAMLAUAjayISW+oa0CNGx5rrIUHAUwJj0fi4SUmAAngAOKKj2cJXIALxoTLjIAD7ISiYace1RMdrsBDCYICrAAPYgyMxwABQFaDWVAJTxmfQ2YAj2yPMAdEmrCZYkCHD0KAzNLDS4YJhQU-R7XLzIAFTIz68QbifIZwuRmUqm6NyyEHujy+exsdh2n2eHi8Pj+J0Bl1S-XBdweUwAsnAHHsAAoASQ+MOyuXylOe1Ly9DRlgoEHgmE0vky-wQk3oYGQAH0IAAPGr5MDAABuEAiHgQpH4EBlUAaXzRknEQA
  - `Not all code paths return a value.`
- `strictNullChecks` is on: https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgMoEcCucooN4BQyxyA1qACYBcyARAM5Y4S0DcRJ9wAXhDSJgC2AI2jsAvgQKhIsRCgBKEBGDggA5gBt8HYuRDU6uFWq0t2JZAHdgFMAAt+Q0VAsl7EYOvtgnIsQSS0uDQ8EjIAMLAUAjayISW+oa0CNGx5rrIUHAUwJj0fi4SUmAAngAOKKj2cJXIALxoTLjIAD7ISiYace1RMdrsBDCYICrAAPYgyMxwABQFaDWVAJTxmfQ2YAj2yPMAdEmrCZYkCHD0KAzNLDS4YJhQU-R7XLzIAFTIz68QbifIZwuRmUqm6NyyEHujy+exsdh2n2eHi8Pj+J0Bl1S-XBdweUwAsnAHHsAAoASQ+MOyuXylOe1Ly9DRlgoEHgmE0vky-wQk3oYGQAH0IAAPGr5MDAABuEAiHgQpH4EBlUAaXzRknEQA
  - `Not all code paths return a value.`
- `noImplicitReturns` is off: https://www.typescriptlang.org/play/?noImplicitReturns=false#code/JYOwLgpgTgZghgYwgAgMoEcCucooN4BQyxyA1qACYBcyARAM5Y4S0DcRJ9wAXhDSJgC2AI2jsAvgQKhIsRCgBKEBGDggA5gBt8HYuRDU6uFWq0t2JZAHdgFMAAt+Q0VAsl7EYOvtgnIsQSS0uDQ8EjIAMLAUAjayISW+oa0CNGx5rrIUHAUwJj0fi4SUmAAngAOKKj2cJXIALxoTLjIAD7ISiYace1RMdrsBDCYICrAAPYgyMxwABQFaDWVAJTxmfQ2YAj2yPMAdEmrCZYkCHD0KAzNLDS4YJhQU-R7XLzIAFTIz68QbifIZwuRmUqm6NyyEHujy+exsdh2n2eHi8Pj+J0Bl1S-XBdweUwAsnAHHsAAoASQ+MOyuXylOe1Ly9DRlgoEHgmE0vky-wQk3oYGQAH0IAAPGr5MDAABuEAiHgQpH4EBlUAaXzRknEQA
  - No errors!


